### PR TITLE
Improve Dockerfile with JRE, non-root user, and layer caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.githooks
+.vscode
+.idea
+target
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM maven:3.9-eclipse-temurin-21-jammy AS build_step
-RUN mkdir /build
-COPY . /build
 WORKDIR /build
-RUN mvn clean package -DskipTests
+COPY pom.xml .
+RUN mvn dependency:go-offline -q
+COPY src ./src
+RUN mvn clean package -DskipTests -q
 
-FROM eclipse-temurin:21-jdk-jammy
-RUN mkdir /app
-COPY --from=build_step /build/target/dflmngr-online-1.0-SNAPSHOT.jar \
-                       /app/
-
+FROM eclipse-temurin:21-jre-jammy
+RUN useradd -r -u 1001 -g root appuser
 WORKDIR /app
-CMD java -jar /app/dflmngr-online-1.0-SNAPSHOT.jar
+COPY --from=build_step /build/target/dflmngr-online-1.0-SNAPSHOT.jar app.jar
+USER appuser
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
## Summary
- Switch runtime image to `eclipse-temurin:21-jre-jammy` (smaller, no compiler tools in prod)
- Run app as non-root `appuser` (uid 1001) for security
- Cache Maven dependencies by copying `pom.xml` before source for faster rebuilds
- Use `ENTRYPOINT` array form for proper JVM signal handling
- Add `.dockerignore` to exclude `.git`, `target`, and IDE files from build context

## Test plan
- [ ] Build image locally: `docker build -t dflmngr-online .`
- [ ] Verify app starts: `docker run -p 8080:8080 dflmngr-online`

🤖 Generated with [Claude Code](https://claude.com/claude-code)