### PR TITLE
Add Lombok to eliminate boilerplate in entity and model classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
         <dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>

--- a/src/main/java/net/dflmngr/model/entities/AflPlayer.java
+++ b/src/main/java/net/dflmngr/model/entities/AflPlayer.java
@@ -6,156 +6,36 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "afl_player")
+@Getter @Setter @ToString @EqualsAndHashCode
 public class AflPlayer {
-	
+
 	@Id
 	@Column(name = "player_id")
 	private String playerId;
-	
+
 	@Column(name = "jumper_no")
 	private int jumperNo;
-	
+
 	@Column(name = "first_name")
 	private String firstName;
-	
+
 	@Column(name = "second_name")
 	private String secondName;
-	
+
 	@Column(name = "team_id")
 	private String teamId;
-	
+
 	private int height;
 	private int weight;
 	private Date dob;
-	
+
 	@Column(name = "dfl_player_id")
 	private int dflPlayerId;
-	
-	public String getPlayerId() {
-		return playerId;
-	}
-	public void setPlayerId(String playerId) {
-		this.playerId = playerId;
-	}
-	public int getJumperNo() {
-		return jumperNo;
-	}
-	public void setJumperNo(int jumperNo) {
-		this.jumperNo = jumperNo;
-	}
-	public String getFirstName() {
-		return firstName;
-	}
-	public void setFirstName(String firstName) {
-		this.firstName = firstName;
-	}
-	public String getSecondName() {
-		return secondName;
-	}
-	public void setSecondName(String secondName) {
-		this.secondName = secondName;
-	}
-	public String getTeamId() {
-		return teamId;
-	}
-	public void setTeamId(String teamId) {
-		this.teamId = teamId;
-	}
-	public int getHeight() {
-		return height;
-	}
-	public void setHeight(int height) {
-		this.height = height;
-	}
-	public int getWeight() {
-		return weight;
-	}
-	public void setWeight(int weight) {
-		this.weight = weight;
-	}
-	public Date getDob() {
-		return dob;
-	}
-	public void setDob(Date dob) {
-		this.dob = dob;
-	}
-	
-	public int getDflPlayerId() {
-		return dflPlayerId;
-	}
-	public void setDflPlayerId(int dflPlayerId) {
-		this.dflPlayerId = dflPlayerId;
-	}
-	
-	@Override
-	public String toString() {
-		return "AflPlayer [playerId=" + playerId + ", jumperNo=" + jumperNo + ", firstName=" + firstName
-				+ ", secondName=" + secondName + ", teamId=" + teamId + ", height=" + height + ", weight=" + weight
-				+ ", dob=" + dob + ", dflPlayerId=" + dflPlayerId + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + dflPlayerId;
-		result = prime * result + ((dob == null) ? 0 : dob.hashCode());
-		result = prime * result + ((firstName == null) ? 0 : firstName.hashCode());
-		result = prime * result + height;
-		result = prime * result + jumperNo;
-		result = prime * result + ((playerId == null) ? 0 : playerId.hashCode());
-		result = prime * result + ((secondName == null) ? 0 : secondName.hashCode());
-		result = prime * result + ((teamId == null) ? 0 : teamId.hashCode());
-		result = prime * result + weight;
-		return result;
-	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		AflPlayer other = (AflPlayer) obj;
-		if (dflPlayerId != other.dflPlayerId)
-			return false;
-		if (dob == null) {
-			if (other.dob != null)
-				return false;
-		} else if (!dob.equals(other.dob))
-			return false;
-		if (firstName == null) {
-			if (other.firstName != null)
-				return false;
-		} else if (!firstName.equals(other.firstName))
-			return false;
-		if (height != other.height)
-			return false;
-		if (jumperNo != other.jumperNo)
-			return false;
-		if (playerId == null) {
-			if (other.playerId != null)
-				return false;
-		} else if (!playerId.equals(other.playerId))
-			return false;
-		if (secondName == null) {
-			if (other.secondName != null)
-				return false;
-		} else if (!secondName.equals(other.secondName))
-			return false;
-		if (teamId == null) {
-			if (other.teamId != null)
-				return false;
-		} else if (!teamId.equals(other.teamId))
-			return false;
-		if (weight != other.weight)
-			return false;
-		return true;
-	}
 }
-

--- a/src/main/java/net/dflmngr/model/entities/DflFixture.java
+++ b/src/main/java/net/dflmngr/model/entities/DflFixture.java
@@ -5,63 +5,29 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import net.dflmngr.model.entities.keys.DflFixturePK;
 
 @Entity
-@Table(name="dfl_fixture")
+@Table(name = "dfl_fixture")
 @IdClass(DflFixturePK.class)
+@Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
 public class DflFixture {
-	
+
 	@Id
 	private int round;
-	
+
 	@Id
 	private int game;
-	
-	@Column(name="home_team")
+
+	@Column(name = "home_team")
 	private String homeTeam;
-	
-	@Column(name="away_team")
+
+	@Column(name = "away_team")
 	private String awayTeam;
-	
-	public DflFixture() {}
-	
-	public DflFixture(int round, int game, String homeTeam, String awayTeam) {
-		this.round = round;
-		this.game = game;
-		this.homeTeam = homeTeam;
-		this.awayTeam = awayTeam;
-	}
-	
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public int getGame() {
-		return game;
-	}
-	public void setGame(int game) {
-		this.game = game;
-	}
-	public String getHomeTeam() {
-		return homeTeam;
-	}
-	public void setHomeTeam(String homeTeam) {
-		this.homeTeam = homeTeam;
-	}
-	public String getAwayTeam() {
-		return awayTeam;
-	}
-	public void setAwayTeam(String awayTeam) {
-		this.awayTeam = awayTeam;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflFixture [round=" + round + ", game=" + game + ", homeTeam=" + homeTeam + ", awayTeam=" + awayTeam
-				+ "]";
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/DflLadder.java
+++ b/src/main/java/net/dflmngr/model/entities/DflLadder.java
@@ -7,252 +7,57 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import net.dflmngr.model.entities.keys.DflLadderPK;
 
 @Entity
-@Table(name="dfl_ladder")
+@Table(name = "dfl_ladder")
 @IdClass(DflLadderPK.class)
+@Getter @Setter @ToString @EqualsAndHashCode
 public class DflLadder implements Comparator<DflLadder>, Comparable<DflLadder> {
 
 	@Id
 	private int round;
-	
+
 	@Id
-	@Column(name="team_code")
+	@Column(name = "team_code")
 	private String teamCode;
-	
+
 	private int wins;
 	private int losses;
 	private int draws;
-	
-	@Column(name="points_for")
+
+	@Column(name = "points_for")
 	private int pointsFor;
-	
-	@Column(name="points_against")
+
+	@Column(name = "points_against")
 	private int pointsAgainst;
-	
-	@Column(name="average_for")
+
+	@Column(name = "average_for")
 	private float averageFor;
-	
-	@Column(name="average_against")
+
+	@Column(name = "average_against")
 	private float averageAgainst;
-	
+
 	private int pts;
 	private float percentage;
 	private boolean live;
-	
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public String getTeamCode() {
-		return teamCode;
-	}
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
-	public int getWins() {
-		return wins;
-	}
-	public void setWins(int wins) {
-		this.wins = wins;
-	}
-	public int getLosses() {
-		return losses;
-	}
-	public void setLosses(int losses) {
-		this.losses = losses;
-	}
-	public int getDraws() {
-		return draws;
-	}
-	public void setDraws(int draws) {
-		this.draws = draws;
-	}
-	public int getPointsFor() {
-		return pointsFor;
-	}
-	public void setPointsFor(int pointsFor) {
-		this.pointsFor = pointsFor;
-	}
-	public int getPointsAgainst() {
-		return pointsAgainst;
-	}
-	public void setPointsAgainst(int pointsAgainst) {
-		this.pointsAgainst = pointsAgainst;
-	}
-	public float getAverageFor() {
-		return averageFor;
-	}
-	public void setAverageFor(float averageFor) {
-		this.averageFor = averageFor;
-	}
-	public float getAverageAgainst() {
-		return averageAgainst;
-	}
-	public void setAverageAgainst(float averageAgainst) {
-		this.averageAgainst = averageAgainst;
-	}
-	public int getPts() {
-		return pts;
-	}
-	public void setPts(int pts) {
-		this.pts = pts;
-	}
-	public float getPercentage() {
-		return percentage;
-	}
-	public void setPercentage(float percentage) {
-		this.percentage = percentage;
-	}
-	public boolean isLive() {
-		return live;
-	}
-	public void setLive(boolean live) {
-		this.live = live;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflLadder [round=" + round + ", teamCode=" + teamCode + ", wins=" + wins + ", losses=" + losses
-				+ ", draws=" + draws + ", pointsFor=" + pointsFor + ", pointsAgainst=" + pointsAgainst + ", averageFor="
-				+ averageFor + ", averageAgainst=" + averageAgainst + ", pts=" + pts + ", percentage=" + percentage
-				+ ", live=" + live + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + round;
-		result = prime * result + ((teamCode == null) ? 0 : teamCode.hashCode());
-		result = prime * result + wins;
-		result = prime * result + losses;
-		result = prime * result + draws;
-		result = prime * result + pointsFor;
-		result = prime * result + pointsAgainst;
-		result = prime * result + Float.floatToIntBits(averageFor);
-		result = prime * result + Float.floatToIntBits(averageAgainst);
-		result = prime * result + pts;
-		result = prime * result + Float.floatToIntBits(percentage);
-		result = prime * result + (live ? 1231 : 1237);
-		return result;
-	}
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflLadder other = (DflLadder) obj;
-		if (round != other.round)
-			return false;
-		if (teamCode == null) {
-			if (other.teamCode != null)
-				return false;
-		} else if (!teamCode.equals(other.teamCode))
-			return false;
-		if (wins != other.wins)
-			return false;
-		if (losses != other.losses)
-			return false;
-		if (draws != other.draws)
-			return false;
-		if (pointsFor != other.pointsFor)
-			return false;
-		if (pointsAgainst != other.pointsAgainst)
-			return false;
-		if (Float.floatToIntBits(averageFor) != Float.floatToIntBits(other.averageFor))
-			return false;
-		if (Float.floatToIntBits(averageAgainst) != Float.floatToIntBits(other.averageAgainst))
-			return false;
-		if (pts != other.pts)
-			return false;
-		if (Float.floatToIntBits(percentage) != Float.floatToIntBits(other.percentage))
-			return false;
-		if (live != other.live)
-			return false;
-		return true;
-	}
-	
 	@Override
 	public int compareTo(DflLadder o) {
-		
-		int equal = 0;
-		int less = -1;
-		int greater = 1;
-		
-
-		int oPts = o.getPts();		
-		if(this.getPts() > oPts) {
-			return greater;
-		}
-		if(this.getPts() < oPts) {
-			return less;
-		}
-
-		float oPercentage = o.getPercentage();		
-		if(this.getPercentage() > oPercentage) {
-			return greater;
-		}
-		if(this.getPercentage() < oPercentage) {
-			return less;
-		}
-		
-		int oPointsFor = o.getPointsFor();		
-		if(this.getPointsFor() > oPointsFor) {
-			return greater;
-		}
-		if(this.getPointsFor() < oPointsFor) {
-			return less;
-		}
-		
-		return equal;
+		if (this.pts != o.pts) return Integer.compare(this.pts, o.pts);
+		if (this.percentage != o.percentage) return Float.compare(this.percentage, o.percentage);
+		return Integer.compare(this.pointsFor, o.pointsFor);
 	}
-	
+
 	@Override
 	public int compare(DflLadder o1, DflLadder o2) {
-
-		int equal = 0;
-		int less = -1;
-		int greater = 1;
-		
-		int o1Pts = o1.getPts();
-		int o2Pts = o2.getPts();
-		
-		if(o1Pts > o2Pts) {
-			return greater;
-		}
-		if(o1Pts < o2Pts) {
-			return less;
-		}
-		
-		float o1Percentage = o1.getPercentage();
-		float o2Percentage = o2.getPercentage();
-		
-		if(o1Percentage > o2Percentage) {
-			return greater;
-		}
-		if(o1Percentage < o2Percentage) {
-			return less;
-		}
-		
-		int o1PointsFor = o1.getPointsFor();
-		int o2PointsFor = o2.getPointsFor();
-		
-		if(o1PointsFor > o2PointsFor) {
-			return greater;
-		}
-		if(o1PointsFor < o2PointsFor) {
-			return less;
-		}
-		
-		return equal;
+		if (o1.pts != o2.pts) return Integer.compare(o1.pts, o2.pts);
+		if (o1.percentage != o2.percentage) return Float.compare(o1.percentage, o2.percentage);
+		return Integer.compare(o1.pointsFor, o2.pointsFor);
 	}
 }

--- a/src/main/java/net/dflmngr/model/entities/DflPlayer.java
+++ b/src/main/java/net/dflmngr/model/entities/DflPlayer.java
@@ -4,109 +4,44 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "dfl_player")
+@Getter @Setter @ToString
 public class DflPlayer {
-	
+
 	@Id
 	@Column(name = "player_id")
 	private int playerId;
-	
+
 	@Column(name = "first_name")
 	private String firstName;
-	
+
 	@Column(name = "last_name")
 	private String lastName;
-	
+
 	private String initial;
 	private String status;
-	
+
 	@Column(name = "afl_club")
 	private String aflClub;
+
 	private String position;
-	
+
 	@Column(name = "afl_player_id")
 	private String aflPlayerId;
-	
+
 	@Column(name = "is_first_year")
 	private boolean isFirstYear;
 
-	public int getPlayerId() {
-		return playerId;
-	}
-
-	public void setPlayerId(int playerId) {
-		this.playerId = playerId;
-	}
-
-	public String getFirstName() {
-		return firstName;
-	}
-
-	public void setFirstName(String firstName) {
-		this.firstName = firstName;
-	}
-
-	public String getLastName() {
-		return lastName;
-	}
-
-	public void setLastName(String lastName) {
-		this.lastName = lastName;
-	}
-
-	public String getInitial() {
-		return initial;
-	}
-
-	public void setInitial(String initial) {
-		this.initial = initial;
-	}
-
-	public String getStatus() {
-		return status;
-	}
-
-	public void setStatus(String status) {
-		this.status = status;
-	}
-
-	public String getAflClub() {
-		return aflClub;
-	}
-
-	public void setAflClub(String aflClub) {
-		this.aflClub = aflClub;
-	}
-
-	public String getPosition() {
-		return position;
-	}
-
-	public void setPosition(String position) {
-		this.position = position;
-	}
-
-	public String getAflPlayerId() {
-		return aflPlayerId;
-	}
-
-	public void setAflPlayerId(String aflPlayerId) {
-		this.aflPlayerId = aflPlayerId;
-	}
 	public boolean isFirstYear() {
 		return isFirstYear;
 	}
 
 	public void setFirstYear(boolean isFirstYear) {
 		this.isFirstYear = isFirstYear;
-	}
-
-	@Override
-	public String toString() {
-		return "DflPlayer [playerId=" + playerId + ", firstName=" + firstName + ", lastName=" + lastName + ", inital="
-				+ initial + ", status=" + status + ", aflClub=" + aflClub + ", position=" + position + ", aflPlayerId="
-				+ aflPlayerId + ", isFirstYear=" + isFirstYear + "]";
 	}
 }

--- a/src/main/java/net/dflmngr/model/entities/DflPlayerPredictedScores.java
+++ b/src/main/java/net/dflmngr/model/entities/DflPlayerPredictedScores.java
@@ -7,138 +7,45 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import net.dflmngr.model.entities.keys.DflPlayerPredictedScoresPK;
 
 @Entity
-@Table(name="dfl_player_predicted_scores")
+@Table(name = "dfl_player_predicted_scores")
 @IdClass(DflPlayerPredictedScoresPK.class)
+@Getter @Setter @ToString @EqualsAndHashCode
 public class DflPlayerPredictedScores implements Comparator<DflPlayerPredictedScores>, Comparable<DflPlayerPredictedScores> {
-	
+
 	@Id
-	@Column(name="player_id")
+	@Column(name = "player_id")
 	private int playerId;
-	
+
 	@Id
 	private int round;
-	
-	@Column(name="afl_player_id")
+
+	@Column(name = "afl_player_id")
 	private String aflPlayerId;
-	
-	@Column(name="team_code")
+
+	@Column(name = "team_code")
 	private String teamCode;
-	
-	@Column(name="team_player_id")
+
+	@Column(name = "team_player_id")
 	private int teamPlayerId;
-	
-	@Column(name="predicted_score")
+
+	@Column(name = "predicted_score")
 	private int predictedScore;
-	
-	public int getPlayerId() {
-		return playerId;
-	}
-	public void setPlayerId(int playerId) {
-		this.playerId = playerId;
-	}
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public String getAflPlayerId() {
-		return aflPlayerId;
-	}
-	public void setAflPlayerId(String aflPlayerId) {
-		this.aflPlayerId = aflPlayerId;
-	}
-	public String getTeamCode() {
-		return teamCode;
-	}
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
-	public int getTeamPlayerId() {
-		return teamPlayerId;
-	}
-	public void setTeamPlayerId(int teamPlayerId) {
-		this.teamPlayerId = teamPlayerId;
-	}
-	public int getPredictedScore() {
-		return predictedScore;
-	}
-	public void setPredictedScore(int predictedScore) {
-		this.predictedScore = predictedScore;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflPlayerPredictedScores [playerId=" + playerId + ", round=" + round + ", aflPlayerId=" + aflPlayerId
-				+ ", teamCode=" + teamCode + ", teamPlayerId=" + teamPlayerId + ", predictedScore=" + predictedScore
-				+ "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((aflPlayerId == null) ? 0 : aflPlayerId.hashCode());
-		result = prime * result + playerId;
-		result = prime * result + predictedScore;
-		result = prime * result + round;
-		result = prime * result + ((teamCode == null) ? 0 : teamCode.hashCode());
-		result = prime * result + teamPlayerId;
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflPlayerPredictedScores other = (DflPlayerPredictedScores) obj;
-		if (aflPlayerId == null) {
-			if (other.aflPlayerId != null)
-				return false;
-		} else if (!aflPlayerId.equals(other.aflPlayerId))
-			return false;
-		if (playerId != other.playerId)
-			return false;
-		if (predictedScore != other.predictedScore)
-			return false;
-		if (round != other.round)
-			return false;
-		if (teamCode == null) {
-			if (other.teamCode != null)
-				return false;
-		} else if (!teamCode.equals(other.teamCode))
-			return false;
-		if (teamPlayerId != other.teamPlayerId)
-			return false;
-		return true;
-	}
-	
+
 	@Override
 	public int compareTo(DflPlayerPredictedScores o) {
-		int equal = 0;
-		if(predictedScore > o.predictedScore) {
-			equal = 1;
-		} else if(this.predictedScore < o.predictedScore) {
-			equal = -1;
-		}
-		return equal;
+		return Integer.compare(this.predictedScore, o.predictedScore);
 	}
-	
+
 	@Override
 	public int compare(DflPlayerPredictedScores o1, DflPlayerPredictedScores o2) {
-		int equal = 0;
-		if(o1.predictedScore > o2.predictedScore) {
-			equal = 1;
-		} else if(o1.predictedScore < o2.predictedScore) {
-			equal = -1;
-		}
-		return equal;
+		return Integer.compare(o1.predictedScore, o2.predictedScore);
 	}
 }

--- a/src/main/java/net/dflmngr/model/entities/DflPlayerScores.java
+++ b/src/main/java/net/dflmngr/model/entities/DflPlayerScores.java
@@ -7,135 +7,44 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import net.dflmngr.model.entities.keys.DflPlayerScoresPK;
 
 @Entity
-@Table(name="dfl_player_scores")
+@Table(name = "dfl_player_scores")
 @IdClass(DflPlayerScoresPK.class)
+@Getter @Setter @ToString @EqualsAndHashCode
 public class DflPlayerScores implements Comparator<DflPlayerScores>, Comparable<DflPlayerScores> {
-	
+
 	@Id
-	@Column(name="player_id")
+	@Column(name = "player_id")
 	private int playerId;
-	
+
 	@Id
 	private int round;
-	
-	@Column(name="afl_player_id")
+
+	@Column(name = "afl_player_id")
 	private String aflPlayerId;
-	
-	@Column(name="team_code")
+
+	@Column(name = "team_code")
 	private String teamCode;
-	
-	@Column(name="team_player_id")
+
+	@Column(name = "team_player_id")
 	private int teamPlayerId;
+
 	private int score;
-	
-	public int getPlayerId() {
-		return playerId;
-	}
-	public void setPlayerId(int playerId) {
-		this.playerId = playerId;
-	}
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public String getAflPlayerId() {
-		return aflPlayerId;
-	}
-	public void setAflPlayerId(String aflPlayerId) {
-		this.aflPlayerId = aflPlayerId;
-	}
-	public String getTeamCode() {
-		return teamCode;
-	}
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
-	public int getTeamPlayerId() {
-		return teamPlayerId;
-	}
-	public void setTeamPlayerId(int teamPlayerId) {
-		this.teamPlayerId = teamPlayerId;
-	}
-	public int getScore() {
-		return score;
-	}
-	public void setScore(int score) {
-		this.score = score;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflPlayerScores [playerId=" + playerId + ", round=" + round + ", aflPlayerId=" + aflPlayerId
-				+ ", teamCode=" + teamCode + ", teamPlayerId=" + teamPlayerId + ", score=" + score + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((aflPlayerId == null) ? 0 : aflPlayerId.hashCode());
-		result = prime * result + playerId;
-		result = prime * result + round;
-		result = prime * result + score;
-		result = prime * result + ((teamCode == null) ? 0 : teamCode.hashCode());
-		result = prime * result + teamPlayerId;
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflPlayerScores other = (DflPlayerScores) obj;
-		if (aflPlayerId == null) {
-			if (other.aflPlayerId != null)
-				return false;
-		} else if (!aflPlayerId.equals(other.aflPlayerId))
-			return false;
-		if (playerId != other.playerId)
-			return false;
-		if (round != other.round)
-			return false;
-		if (score != other.score)
-			return false;
-		if (teamCode == null) {
-			if (other.teamCode != null)
-				return false;
-		} else if (!teamCode.equals(other.teamCode))
-			return false;
-		if (teamPlayerId != other.teamPlayerId)
-			return false;
-		return true;
-	}
-	
+
 	@Override
 	public int compareTo(DflPlayerScores o) {
-		int equal = 0;
-		if(this.score > o.score) {
-			equal = 1;
-		} else if(this.score < o.score) {
-			equal = -1;
-		}
-		return equal;
+		return Integer.compare(this.score, o.score);
 	}
-	
+
 	@Override
 	public int compare(DflPlayerScores o1, DflPlayerScores o2) {
-		int equal = 0;
-		if(o1.score > o2.score) {
-			equal = 1;
-		} else if(o1.score < o2.score) {
-			equal = -1;
-		}
-		return equal;
+		return Integer.compare(o1.score, o2.score);
 	}
 }

--- a/src/main/java/net/dflmngr/model/entities/DflSelectedPlayer.java
+++ b/src/main/java/net/dflmngr/model/entities/DflSelectedPlayer.java
@@ -5,152 +5,56 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import net.dflmngr.model.entities.keys.DflSelectedPlayerPK;
 
 @Entity
-@Table(name="dfl_selected_player")
+@Table(name = "dfl_selected_player")
 @IdClass(DflSelectedPlayerPK.class)
+@Getter @Setter @ToString @EqualsAndHashCode
 public class DflSelectedPlayer {
-	
+
 	@Id
 	private int round;
-	
+
 	@Id
 	@Column(name = "player_id")
 	private int playerId;
-	
+
 	@Column(name = "team_player_id")
 	private int teamPlayerId;
-	
+
 	@Column(name = "team_code")
 	private String teamCode;
-	
+
 	@Column(name = "is_emergency")
 	private int isEmergency;
-	
+
 	@Column(name = "is_dnp")
 	private boolean isDnp;
-	
+
 	@Column(name = "score_used")
 	private boolean scoreUsed;
-	
+
 	@Column(name = "has_played")
 	private boolean hasPlayed;
-	
+
 	@Column(name = "replacement_ind")
 	private String replacementInd;
-	
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public int getPlayerId() {
-		return playerId;
-	}
-	public void setPlayerId(int playerId) {
-		this.playerId = playerId;
-	}
-	public int getTeamPlayerId() {
-		return teamPlayerId;
-	}
-	public void setTeamPlayerId(int teamPlayerId) {
-		this.teamPlayerId = teamPlayerId;
-	}
-	public String getTeamCode() {
-		return teamCode;
-	}
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
+
 	public int isEmergency() {
 		return isEmergency;
 	}
+
 	public void setEmergency(int isEmergency) {
 		this.isEmergency = isEmergency;
 	}
-	public boolean isDnp() {
-		return isDnp;
-	}
-	public void setDnp(boolean isDnp) {
-		this.isDnp = isDnp;
-	}
-	public boolean isScoreUsed() {
-		return scoreUsed;
-	}
-	public void setScoreUsed(boolean scoreUsed) {
-		this.scoreUsed = scoreUsed;
-	}
+
 	public boolean hasPlayed() {
 		return hasPlayed;
-	}
-	public void setHasPlayed(boolean hasPlayed) {
-		this.hasPlayed = hasPlayed;
-	}
-	public String getReplacementInd() {
-		return replacementInd;
-	}
-	public void setReplacementInd(String replacementInd) {
-		this.replacementInd = replacementInd;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflSelectedPlayer [round=" + round + ", playerId=" + playerId + ", teamPlayerId=" + teamPlayerId
-				+ ", teamCode=" + teamCode + ", isEmergency=" + isEmergency + ", isDnp=" + isDnp + ", scoreUsed="
-				+ scoreUsed + ", hasPlayed=" + hasPlayed + ", replacementInd=" + replacementInd + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + (hasPlayed ? 1231 : 1237);
-		result = prime * result + (isDnp ? 1231 : 1237);
-		result = prime * result + isEmergency;
-		result = prime * result + playerId;
-		result = prime * result + ((replacementInd == null) ? 0 : replacementInd.hashCode());
-		result = prime * result + round;
-		result = prime * result + (scoreUsed ? 1231 : 1237);
-		result = prime * result + ((teamCode == null) ? 0 : teamCode.hashCode());
-		result = prime * result + teamPlayerId;
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflSelectedPlayer other = (DflSelectedPlayer) obj;
-		if (hasPlayed != other.hasPlayed)
-			return false;
-		if (isDnp != other.isDnp)
-			return false;
-		if (isEmergency != other.isEmergency)
-			return false;
-		if (playerId != other.playerId)
-			return false;
-		if (replacementInd == null) {
-			if (other.replacementInd != null)
-				return false;
-		} else if (!replacementInd.equals(other.replacementInd))
-			return false;
-		if (round != other.round)
-			return false;
-		if (scoreUsed != other.scoreUsed)
-			return false;
-		if (teamCode == null) {
-			if (other.teamCode != null)
-				return false;
-		} else if (!teamCode.equals(other.teamCode))
-			return false;
-		if (teamPlayerId != other.teamPlayerId)
-			return false;
-		return true;
 	}
 }

--- a/src/main/java/net/dflmngr/model/entities/DflTeam.java
+++ b/src/main/java/net/dflmngr/model/entities/DflTeam.java
@@ -4,90 +4,34 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(name = "dfl_team")
+@Getter @Setter @ToString @NoArgsConstructor @AllArgsConstructor
 public class DflTeam {
-	
+
 	@Id
 	@Column(name = "team_code")
 	private String teamCode;
+
 	private String name;
-	
+
 	@Column(name = "short_name")
 	private String shortName;
-	
+
 	@Column(name = "coach_name")
 	private String coachName;
-	
+
 	@Column(name = "home_ground")
 	private String homeGround;
-	
+
 	private String colours;
-	
+
 	@Column(name = "coach_email")
 	private String coachEmail;
-	
-	public DflTeam() {}
-	
-	public DflTeam(String teamCode, String name, String shortName, String coachName, String homeGround, String colours,
-			String coachEmail) {
-		this.teamCode = teamCode;
-		this.name = name;
-		this.shortName = shortName;
-		this.coachName = coachName;
-		this.homeGround = homeGround;
-		this.colours = colours;
-		this.coachEmail = coachEmail;
-	}
-	
-	public String getTeamCode() {
-		return teamCode;
-	}
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
-	public String getName() {
-		return name;
-	}
-	public void setName(String name) {
-		this.name = name;
-	}
-	public String getShortName() {
-		return shortName;
-	}
-	public void setShortName(String shortName) {
-		this.shortName = shortName;
-	}
-	public String getCoachName() {
-		return coachName;
-	}
-	public void setCoachName(String coachName) {
-		this.coachName = coachName;
-	}
-	public String getHomeGround() {
-		return homeGround;
-	}
-	public void setHomeGround(String homeGround) {
-		this.homeGround = homeGround;
-	}
-	public String getColours() {
-		return colours;
-	}
-	public void setColours(String colours) {
-		this.colours = colours;
-	}
-	public String getCoachEmail() {
-		return coachEmail;
-	}
-	public void setCoachEmail(String coachEmail) {
-		this.coachEmail = coachEmail;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflTeam [teamCode=" + teamCode + ", name=" + name + ", shortName=" + shortName + ", coachName="
-				+ coachName + ", homeGround=" + homeGround + ", colours=" + colours + ", coachEmail=" + coachEmail
-				+ "]";
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/DflTeamPredictedScores.java
+++ b/src/main/java/net/dflmngr/model/entities/DflTeamPredictedScores.java
@@ -5,75 +5,26 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import net.dflmngr.model.entities.keys.DflTeamPredictedScoresPK;
 
 @Entity
-@Table(name="dfl_team_predicted_scores")
+@Table(name = "dfl_team_predicted_scores")
 @IdClass(DflTeamPredictedScoresPK.class)
+@Getter @Setter @ToString @EqualsAndHashCode
 public class DflTeamPredictedScores {
-	
+
 	@Id
-	@Column(name="team_code")
+	@Column(name = "team_code")
 	private String teamCode;
-	
+
 	@Id
 	private int round;
-	
-	@Column(name="predicted_score")
+
+	@Column(name = "predicted_score")
 	private int predictedScore;
-	
-	public String getTeamCode() {
-		return teamCode;
-	}
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public int getPredictedScore() {
-		return predictedScore;
-	}
-	public void setPredictedScore(int predictedScore) {
-		this.predictedScore = predictedScore;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflTeamScores [teamCode=" + teamCode + ", round=" + round + ", score=" + predictedScore + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + round;
-		result = prime * result + predictedScore;
-		result = prime * result + ((teamCode == null) ? 0 : teamCode.hashCode());
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflTeamPredictedScores other = (DflTeamPredictedScores) obj;
-		if (round != other.round)
-			return false;
-		if (predictedScore != other.predictedScore)
-			return false;
-		if (teamCode == null) {
-			if (other.teamCode != null)
-				return false;
-		} else if (!teamCode.equals(other.teamCode))
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/DflTeamScores.java
+++ b/src/main/java/net/dflmngr/model/entities/DflTeamScores.java
@@ -5,73 +5,25 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import net.dflmngr.model.entities.keys.DflTeamScoresPK;
 
 @Entity
-@Table(name="dfl_team_scores")
+@Table(name = "dfl_team_scores")
 @IdClass(DflTeamScoresPK.class)
+@Getter @Setter @ToString @EqualsAndHashCode
 public class DflTeamScores {
-	
+
 	@Id
-	@Column(name="team_code")
+	@Column(name = "team_code")
 	private String teamCode;
-	
+
 	@Id
 	private int round;
+
 	private int score;
-	
-	public String getTeamCode() {
-		return teamCode;
-	}
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public int getScore() {
-		return score;
-	}
-	public void setScore(int score) {
-		this.score = score;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflTeamScores [teamCode=" + teamCode + ", round=" + round + ", score=" + score + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + round;
-		result = prime * result + score;
-		result = prime * result + ((teamCode == null) ? 0 : teamCode.hashCode());
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflTeamScores other = (DflTeamScores) obj;
-		if (round != other.round)
-			return false;
-		if (score != other.score)
-			return false;
-		if (teamCode == null) {
-			if (other.teamCode != null)
-				return false;
-		} else if (!teamCode.equals(other.teamCode))
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/Globals.java
+++ b/src/main/java/net/dflmngr/model/entities/Globals.java
@@ -2,113 +2,28 @@ package net.dflmngr.model.entities;
 
 import java.io.Serializable;
 import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import net.dflmngr.model.entities.keys.GlobalsPK;
 
 @Entity
-@Table(name="globals")
+@Table(name = "globals")
 @IdClass(GlobalsPK.class)
+@Getter @Setter @ToString @EqualsAndHashCode
 public class Globals implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
 	@Id
 	private String code;
-	
-	@Id @Column(name = "group_code")
+
+	@Id
+	@Column(name = "group_code")
 	private String groupCode;
 
 	private String params;
 	private String value;
-
-	public String getCode() {
-		return this.code;
-	}
-
-	public void setCode(String code) {
-		this.code = code;
-	}
-
-	public String getGroupCode() {
-		return this.groupCode;
-	}
-
-	public void setGroupCode(String groupCode) {
-		this.groupCode = groupCode;
-	}
-
-	public String getParams() {
-		return this.params;
-	}
-
-	public void setParams(String params) {
-		this.params = params;
-	}
-
-	public String getValue() {
-		return this.value;
-	}
-
-	public void setValue(String value) {
-		this.value = value;
-	}
-
-	@Override
-	public String toString() {
-		return "Global [code=" + code + ", groupCode=" + groupCode + ", params=" + params + ", value=" + value + "]";
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((code == null) ? 0 : code.hashCode());
-		result = prime * result + ((groupCode == null) ? 0 : groupCode.hashCode());
-		result = prime * result + ((params == null) ? 0 : params.hashCode());
-		result = prime * result + ((value == null) ? 0 : value.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		Globals other = (Globals) obj;
-		if (code == null) {
-			if (other.code != null) {
-				return false;
-			}
-		} else if (!code.equals(other.code)) {
-			return false;
-		}
-		if (groupCode == null) {
-			if (other.groupCode != null) {
-				return false;
-			}
-		} else if (!groupCode.equals(other.groupCode)) {
-			return false;
-		}
-		if (params == null) {
-			if (other.params != null) {
-				return false;
-			}
-		} else if (!params.equals(other.params)) {
-			return false;
-		}
-		if (value == null) {
-			if (other.value != null) {
-				return false;
-			}
-		} else if (!value.equals(other.value)) {
-			return false;
-		}
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/RawPlayerStats.java
+++ b/src/main/java/net/dflmngr/model/entities/RawPlayerStats.java
@@ -7,214 +7,49 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import net.dflmngr.model.entities.keys.RawPlayerStatsPK;
 
 @Entity
-@Table(name="raw_player_stats")
+@Table(name = "raw_player_stats")
 @IdClass(RawPlayerStatsPK.class)
+@Getter @Setter @ToString @EqualsAndHashCode
 public class RawPlayerStats implements Serializable {
 
 	private static final long serialVersionUID = 1L;
-	
+
 	@Id
 	private int round;
+
 	@Id
 	private String name;
+
 	@Id
 	String team;
-	
-	@Column(name="jumper_no")
+
+	@Column(name = "jumper_no")
 	private int jumperNo;
-	
+
 	private int kicks;
 	private int handballs;
 	private int disposals;
 	private int marks;
 	private int hitouts;
-	
-	@Column(name="frees_for")
+
+	@Column(name = "frees_for")
 	private int freesFor;
-	
-	@Column(name="frees_against")
+
+	@Column(name = "frees_against")
 	private int freesAgainst;
-	
+
 	private int tackles;
 	private int goals;
 	private int behinds;
-	
-	@Column(name="scraping_status")
+
+	@Column(name = "scraping_status")
 	private String scrapingStatus;
-	
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public String getName() {
-		return name;
-	}
-	public void setName(String name) {
-		this.name = name;
-	}
-	public String getTeam() {
-		return team;
-	}
-	public void setTeam(String team) {
-		this.team = team;
-	}
-	public int getJumperNo() {
-		return jumperNo;
-	}
-	public void setJumperNo(int jumperNo) {
-		this.jumperNo = jumperNo;
-	}
-	public int getKicks() {
-		return kicks;
-	}
-	public void setKicks(int kicks) {
-		this.kicks = kicks;
-	}
-	public int getHandballs() {
-		return handballs;
-	}
-	public void setHandballs(int handballs) {
-		this.handballs = handballs;
-	}
-	public int getDisposals() {
-		return disposals;
-	}
-	public void setDisposals(int disposals) {
-		this.disposals = disposals;
-	}
-	public int getMarks() {
-		return marks;
-	}
-	public void setMarks(int marks) {
-		this.marks = marks;
-	}
-	public int getHitouts() {
-		return hitouts;
-	}
-	public void setHitouts(int hitouts) {
-		this.hitouts = hitouts;
-	}
-	public int getFreesFor() {
-		return freesFor;
-	}
-	public void setFreesFor(int freesFor) {
-		this.freesFor = freesFor;
-	}
-	public int getFreesAgainst() {
-		return freesAgainst;
-	}
-	public void setFreesAgainst(int freesAgainst) {
-		this.freesAgainst = freesAgainst;
-	}
-	public int getTackles() {
-		return tackles;
-	}
-	public void setTackles(int tackles) {
-		this.tackles = tackles;
-	}
-	public int getGoals() {
-		return goals;
-	}
-	public void setGoals(int goals) {
-		this.goals = goals;
-	}
-	public int getBehinds() {
-		return behinds;
-	}
-	public void setBehinds(int behinds) {
-		this.behinds = behinds;
-	}
-	public String getScrapingStatus() {
-		return scrapingStatus;
-	}
-	public void setScrapingStatus(String scrapingStatus) {
-		this.scrapingStatus = scrapingStatus;
-	}
-	
-	@Override
-	public String toString() {
-		return "RawPlayerStats [round=" + round + ", name=" + name + ", team=" + team + ", jumperNo=" + jumperNo
-				+ ", kicks=" + kicks + ", handballs=" + handballs + ", disposals=" + disposals + ", marks=" + marks
-				+ ", hitouts=" + hitouts + ", freesFor=" + freesFor + ", freesAgainst=" + freesAgainst + ", tackles="
-				+ tackles + ", goals=" + goals + ", behinds=" + behinds + ", scrapingStatus=" + scrapingStatus + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + behinds;
-		result = prime * result + disposals;
-		result = prime * result + freesAgainst;
-		result = prime * result + freesFor;
-		result = prime * result + goals;
-		result = prime * result + handballs;
-		result = prime * result + hitouts;
-		result = prime * result + jumperNo;
-		result = prime * result + kicks;
-		result = prime * result + marks;
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		result = prime * result + round;
-		result = prime * result + ((scrapingStatus == null) ? 0 : scrapingStatus.hashCode());
-		result = prime * result + tackles;
-		result = prime * result + ((team == null) ? 0 : team.hashCode());
-		return result;
-	}
-	
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		RawPlayerStats other = (RawPlayerStats) obj;
-		if (behinds != other.behinds)
-			return false;
-		if (disposals != other.disposals)
-			return false;
-		if (freesAgainst != other.freesAgainst)
-			return false;
-		if (freesFor != other.freesFor)
-			return false;
-		if (goals != other.goals)
-			return false;
-		if (handballs != other.handballs)
-			return false;
-		if (hitouts != other.hitouts)
-			return false;
-		if (jumperNo != other.jumperNo)
-			return false;
-		if (kicks != other.kicks)
-			return false;
-		if (marks != other.marks)
-			return false;
-		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
-			return false;
-		if (round != other.round)
-			return false;
-		if (scrapingStatus == null) {
-			if (other.scrapingStatus != null)
-				return false;
-		} else if (!scrapingStatus.equals(other.scrapingStatus))
-			return false;
-		if (tackles != other.tackles)
-			return false;
-		if (team == null) {
-			if (other.team != null)
-				return false;
-		} else if (!team.equals(other.team))
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/keys/DflFixturePK.java
+++ b/src/main/java/net/dflmngr/model/entities/keys/DflFixturePK.java
@@ -1,52 +1,12 @@
 package net.dflmngr.model.entities.keys;
 
 import java.io.Serializable;
+import lombok.Data;
 
+@Data
 public class DflFixturePK implements Serializable {
 	private static final long serialVersionUID = 1L;
-	
+
 	private int round;
 	private int game;
-	
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public int getGame() {
-		return game;
-	}
-	public void setGame(int game) {
-		this.game = game;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflFixturePK [round=" + round + ", game=" + game + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + game;
-		result = prime * result + round;
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflFixturePK other = (DflFixturePK) obj;
-		if (game != other.game)
-			return false;
-		if (round != other.round)
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/keys/DflLadderPK.java
+++ b/src/main/java/net/dflmngr/model/entities/keys/DflLadderPK.java
@@ -1,56 +1,12 @@
 package net.dflmngr.model.entities.keys;
 
 import java.io.Serializable;
+import lombok.Data;
 
+@Data
 public class DflLadderPK implements Serializable {
-
 	private static final long serialVersionUID = 1L;
-	
+
 	private int round;
 	private String teamCode;
-	
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public String getTeamCode() {
-		return teamCode;
-	}
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
-
-	@Override
-	public String toString() {
-		return "DflLadderPK [round=" + round + ", teamCode=" + teamCode + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + round;
-		result = prime * result + ((teamCode == null) ? 0 : teamCode.hashCode());
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflLadderPK other = (DflLadderPK) obj;
-		if (round != other.round)
-			return false;
-		if (teamCode == null) {
-			if (other.teamCode != null)
-				return false;
-		} else if (!teamCode.equals(other.teamCode))
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/keys/DflPlayerPredictedScoresPK.java
+++ b/src/main/java/net/dflmngr/model/entities/keys/DflPlayerPredictedScoresPK.java
@@ -1,52 +1,12 @@
 package net.dflmngr.model.entities.keys;
 
 import java.io.Serializable;
+import lombok.Data;
 
+@Data
 public class DflPlayerPredictedScoresPK implements Serializable {
 	private static final long serialVersionUID = 1L;
-	
+
 	private int playerId;
 	private int round;
-	
-	public int getPlayerId() {
-		return playerId;
-	}
-	public void setPlayerId(int playerId) {
-		this.playerId = playerId;
-	}
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflPlayerScoresPK [playerId=" + playerId + ", round=" + round + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + playerId;
-		result = prime * result + round;
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflPlayerPredictedScoresPK other = (DflPlayerPredictedScoresPK) obj;
-		if (playerId != other.playerId)
-			return false;
-		if (round != other.round)
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/keys/DflPlayerScoresPK.java
+++ b/src/main/java/net/dflmngr/model/entities/keys/DflPlayerScoresPK.java
@@ -1,52 +1,12 @@
 package net.dflmngr.model.entities.keys;
 
 import java.io.Serializable;
+import lombok.Data;
 
+@Data
 public class DflPlayerScoresPK implements Serializable {
 	private static final long serialVersionUID = 1L;
-	
+
 	private int playerId;
 	private int round;
-	
-	public int getPlayerId() {
-		return playerId;
-	}
-	public void setPlayerId(int playerId) {
-		this.playerId = playerId;
-	}
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflPlayerScoresPK [playerId=" + playerId + ", round=" + round + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + playerId;
-		result = prime * result + round;
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflPlayerScoresPK other = (DflPlayerScoresPK) obj;
-		if (playerId != other.playerId)
-			return false;
-		if (round != other.round)
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/keys/DflSelectedPlayerPK.java
+++ b/src/main/java/net/dflmngr/model/entities/keys/DflSelectedPlayerPK.java
@@ -1,52 +1,12 @@
 package net.dflmngr.model.entities.keys;
 
 import java.io.Serializable;
+import lombok.Data;
 
+@Data
 public class DflSelectedPlayerPK implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	private int round;
 	private int playerId;
-	
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public int getPlayerId() {
-		return playerId;
-	}
-	public void setPlayerId(int playerId) {
-		this.playerId = playerId;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflSelectedTeamPK [round=" + round + ", playerId=" + playerId + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + playerId;
-		result = prime * result + round;
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflSelectedPlayerPK other = (DflSelectedPlayerPK) obj;
-		if (playerId != other.playerId)
-			return false;
-		if (round != other.round)
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/keys/DflTeamPredictedScoresPK.java
+++ b/src/main/java/net/dflmngr/model/entities/keys/DflTeamPredictedScoresPK.java
@@ -1,55 +1,12 @@
 package net.dflmngr.model.entities.keys;
 
 import java.io.Serializable;
+import lombok.Data;
 
+@Data
 public class DflTeamPredictedScoresPK implements Serializable {
 	private static final long serialVersionUID = 1L;
-	
+
 	private String teamCode;
 	private int round;
-	
-	public String getTeamCode() {
-		return teamCode;
-	}
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflTeamPredictedScoresPK [teamCode=" + teamCode + ", round=" + round + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + round;
-		result = prime * result + ((teamCode == null) ? 0 : teamCode.hashCode());
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflTeamPredictedScoresPK other = (DflTeamPredictedScoresPK) obj;
-		if (round != other.round)
-			return false;
-		if (teamCode == null) {
-			if (other.teamCode != null)
-				return false;
-		} else if (!teamCode.equals(other.teamCode))
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/keys/DflTeamScoresPK.java
+++ b/src/main/java/net/dflmngr/model/entities/keys/DflTeamScoresPK.java
@@ -1,55 +1,12 @@
 package net.dflmngr.model.entities.keys;
 
 import java.io.Serializable;
+import lombok.Data;
 
+@Data
 public class DflTeamScoresPK implements Serializable {
 	private static final long serialVersionUID = 1L;
-	
+
 	private String teamCode;
 	private int round;
-	
-	public String getTeamCode() {
-		return teamCode;
-	}
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	
-	@Override
-	public String toString() {
-		return "DflTeamScoresPK [teamCode=" + teamCode + ", round=" + round + "]";
-	}
-	
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + round;
-		result = prime * result + ((teamCode == null) ? 0 : teamCode.hashCode());
-		return result;
-	}
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		DflTeamScoresPK other = (DflTeamScoresPK) obj;
-		if (round != other.round)
-			return false;
-		if (teamCode == null) {
-			if (other.teamCode != null)
-				return false;
-		} else if (!teamCode.equals(other.teamCode))
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/keys/GlobalsPK.java
+++ b/src/main/java/net/dflmngr/model/entities/keys/GlobalsPK.java
@@ -1,70 +1,12 @@
 package net.dflmngr.model.entities.keys;
 
 import java.io.Serializable;
+import lombok.Data;
 
+@Data
 public class GlobalsPK implements Serializable {
-
 	private static final long serialVersionUID = 1L;
-	
+
 	private String code;
 	private String groupCode;
-	
-	public String getCode() {
-		return code;
-	}
-	
-	public void setCode(String code) {
-		this.code = code;
-	}
-	
-	public String getGroupCode() {
-		return groupCode;
-	}
-	
-	public void setGroupCode(String groupCode) {
-		this.groupCode = groupCode;
-	}
-
-	@Override
-	public String toString() {
-		return "GlobalsPK [code=" + code + ", groupCode=" + groupCode + "]";
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((code == null) ? 0 : code.hashCode());
-		result = prime * result + ((groupCode == null) ? 0 : groupCode.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		GlobalsPK other = (GlobalsPK) obj;
-		if (code == null) {
-			if (other.code != null) {
-				return false;
-			}
-		} else if (!code.equals(other.code)) {
-			return false;
-		}
-		if (groupCode == null) {
-			if (other.groupCode != null) {
-				return false;
-			}
-		} else if (!groupCode.equals(other.groupCode)) {
-			return false;
-		}
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/entities/keys/RawPlayerStatsPK.java
+++ b/src/main/java/net/dflmngr/model/entities/keys/RawPlayerStatsPK.java
@@ -1,77 +1,15 @@
 package net.dflmngr.model.entities.keys;
 
 import java.io.Serializable;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
+@NoArgsConstructor
 public class RawPlayerStatsPK implements Serializable {
-
 	private static final long serialVersionUID = 1L;
-	
+
 	private int round;
 	private String name;
 	private String team;
-	
-	public RawPlayerStatsPK() {}
-
-	public int getRound() {
-		return round;
-	}
-
-	public void setRound(int round) {
-		this.round = round;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public String getTeam() {
-		return team;
-	}
-
-	public void setTeam(String team) {
-		this.team = team;
-	}
-
-	@Override
-	public String toString() {
-		return "RawPlayerStatsPK [round=" + round + ", name=" + name + ", team=" + team + "]";
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		result = prime * result + round;
-		result = prime * result + ((team == null) ? 0 : team.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		RawPlayerStatsPK other = (RawPlayerStatsPK) obj;
-		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
-			return false;
-		if (round != other.round)
-			return false;
-		if (team == null) {
-			if (other.team != null)
-				return false;
-		} else if (!team.equals(other.team))
-			return false;
-		return true;
-	}
 }

--- a/src/main/java/net/dflmngr/model/web/GameFixture.java
+++ b/src/main/java/net/dflmngr/model/web/GameFixture.java
@@ -1,83 +1,20 @@
 package net.dflmngr.model.web;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class GameFixture {
 
-	int game;
-	String homeTeam;
-	String awayTeam;
-	int homeTeamScore;
-	int awayTeamScore;
-	String homeTeamDisplayName;
-	String awayTeamDisplayName;
-	String resultsUri;
-	
-	public GameFixture(){}
-	
-	public GameFixture(int game, String homeTeam, String awayTeam, int homeTeamScore, int awayTeamScore,
-			String homeTeamDisplayName, String awayTeamDisplayName, String resultsUri) {
-		this.game = game;
-		this.homeTeam = homeTeam;
-		this.awayTeam = awayTeam;
-		this.homeTeamScore = homeTeamScore;
-		this.awayTeamScore = awayTeamScore;
-		this.homeTeamDisplayName = homeTeamDisplayName;
-		this.awayTeamDisplayName = awayTeamDisplayName;
-		this.resultsUri = resultsUri;
-	}
-	
-	public int getGame() {
-		return game;
-	}
-	public void setGame(int game) {
-		this.game = game;
-	}
-	public String getHomeTeam() {
-		return homeTeam;
-	}
-	public void setHomeTeam(String homeTeam) {
-		this.homeTeam = homeTeam;
-	}
-	public String getAwayTeam() {
-		return awayTeam;
-	}
-	public void setAwayTeam(String awayTeam) {
-		this.awayTeam = awayTeam;
-	}
-	public int getHomeTeamScore() {
-		return homeTeamScore;
-	}
-	public void setHomeTeamScore(int homeTeamScore) {
-		this.homeTeamScore = homeTeamScore;
-	}
-	public int getAwayTeamScore() {
-		return awayTeamScore;
-	}
-	public void setAwayTeamScore(int awayTeamScore) {
-		this.awayTeamScore = awayTeamScore;
-	}
-	public String getHomeTeamDisplayName() {
-		return homeTeamDisplayName;
-	}
-	public void setHomeTeamDisplayName(String homeTeamDisplayName) {
-		this.homeTeamDisplayName = homeTeamDisplayName;
-	}
-	public String getAwayTeamDisplayName() {
-		return awayTeamDisplayName;
-	}
-	public void setAwayTeamDisplayName(String awayTeamDisplayName) {
-		this.awayTeamDisplayName = awayTeamDisplayName;
-	}
-	public String getResultsUri() {
-		return resultsUri;
-	}
-	public void setResultsUri(String resultsUri) {
-		this.resultsUri = resultsUri;
-	}
-	
-	@Override
-	public String toString() {
-		return "GameFixture [game=" + game + ", homeTeam=" + homeTeam + ", awayTeam=" + awayTeam + ", homeTeamScore="
-				+ homeTeamScore + ", awayTeamScore=" + awayTeamScore + ", homeTeamDisplayName=" + homeTeamDisplayName
-				+ ", awayTeamDisplayName=" + awayTeamDisplayName + ", resultsUri=" + resultsUri + "]";
-	}
+	private int game;
+	private String homeTeam;
+	private String awayTeam;
+	private int homeTeamScore;
+	private int awayTeamScore;
+	private String homeTeamDisplayName;
+	private String awayTeamDisplayName;
+	private String resultsUri;
 }

--- a/src/main/java/net/dflmngr/model/web/GameMenu.java
+++ b/src/main/java/net/dflmngr/model/web/GameMenu.java
@@ -1,57 +1,17 @@
 package net.dflmngr.model.web;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class GameMenu {
 
-	int game;
-	String homeTeam;
-	String awayTeam;
-	boolean active;
-	String resultsUri;
-	
-	public GameMenu(){}
-	
-	public GameMenu(int game, String homeTeam, String awayTeam, boolean active, String resultsUri) {
-		this.game = game;
-		this.homeTeam = homeTeam;
-		this.awayTeam = awayTeam;
-		this.active = active;
-		this.resultsUri = resultsUri;
-	}
-
-	public int getGame() {
-		return game;
-	}
-	public void setGame(int game) {
-		this.game = game;
-	}
-	public String getHomeTeam() {
-		return homeTeam;
-	}
-	public void setHomeTeam(String homeTeam) {
-		this.homeTeam = homeTeam;
-	}
-	public String getAwayTeam() {
-		return awayTeam;
-	}
-	public void setAwayTeam(String awayTeam) {
-		this.awayTeam = awayTeam;
-	}
-	public boolean isActive() {
-		return active;
-	}
-	public void setActive(boolean active) {
-		this.active = active;
-	}
-	public String getResultsUri() {
-		return resultsUri;
-	}
-	public void setResultsUri(String resultsUri) {
-		this.resultsUri = resultsUri;
-	}
-
-	@Override
-	public String toString() {
-		return "GameMenu [game=" + game + ", homeTeam=" + homeTeam + ", awayTeam=" + awayTeam + ", active=" + active
-				+ ", resultsUri=" + resultsUri + "]";
-	}
+	private int game;
+	private String homeTeam;
+	private String awayTeam;
+	private boolean active;
+	private String resultsUri;
 }

--- a/src/main/java/net/dflmngr/model/web/Ladder.java
+++ b/src/main/java/net/dflmngr/model/web/Ladder.java
@@ -1,12 +1,19 @@
 package net.dflmngr.model.web;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Ladder {
 
 	private int round;
 	private String teamCode;
 	private int wins;
 	private int losses;
-	private int draws;	
+	private int draws;
 	private int pointsFor;
 	private int pointsAgainst;
 	private float averageFor;
@@ -15,135 +22,4 @@ public class Ladder {
 	private float percentage;
 	private String displayName;
 	private String teamUri;
-	
-	public Ladder() {}
-
-	public Ladder(int round, String teamCode, int wins, int losses, int draws, int pointsFor, int pointsAgainst,
-			float averageFor, float averageAgainst, int pts, float percentage, String displayName, String teamUri) {
-		this.round = round;
-		this.teamCode = teamCode;
-		this.wins = wins;
-		this.losses = losses;
-		this.draws = draws;
-		this.pointsFor = pointsFor;
-		this.pointsAgainst = pointsAgainst;
-		this.averageFor = averageFor;
-		this.averageAgainst = averageAgainst;
-		this.pts = pts;
-		this.percentage = percentage;
-		this.displayName = displayName;
-		this.teamUri = teamUri;
-	}
-
-	public int getRound() {
-		return round;
-	}
-
-	public void setRound(int round) {
-		this.round = round;
-	}
-
-	public String getTeamCode() {
-		return teamCode;
-	}
-
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
-
-	public int getWins() {
-		return wins;
-	}
-
-	public void setWins(int wins) {
-		this.wins = wins;
-	}
-
-	public int getLosses() {
-		return losses;
-	}
-
-	public void setLosses(int losses) {
-		this.losses = losses;
-	}
-
-	public int getDraws() {
-		return draws;
-	}
-
-	public void setDraws(int draws) {
-		this.draws = draws;
-	}
-
-	public int getPointsFor() {
-		return pointsFor;
-	}
-
-	public void setPointsFor(int pointsFor) {
-		this.pointsFor = pointsFor;
-	}
-
-	public int getPointsAgainst() {
-		return pointsAgainst;
-	}
-
-	public void setPointsAgainst(int pointsAgainst) {
-		this.pointsAgainst = pointsAgainst;
-	}
-
-	public float getAverageFor() {
-		return averageFor;
-	}
-
-	public void setAverageFor(float averageFor) {
-		this.averageFor = averageFor;
-	}
-
-	public float getAverageAgainst() {
-		return averageAgainst;
-	}
-
-	public void setAverageAgainst(float averageAgainst) {
-		this.averageAgainst = averageAgainst;
-	}
-
-	public int getPts() {
-		return pts;
-	}
-
-	public void setPts(int pts) {
-		this.pts = pts;
-	}
-
-	public float getPercentage() {
-		return percentage;
-	}
-
-	public void setPercentage(float percentage) {
-		this.percentage = percentage;
-	}
-
-	public String getDisplayName() {
-		return displayName;
-	}
-
-	public void setDisplayName(String displayName) {
-		this.displayName = displayName;
-	}
-
-	public String getTeamUri() {
-		return teamUri;
-	}
-
-	public void setTeamUri(String teamUri) {
-		this.teamUri = teamUri;
-	}
-
-	@Override
-	public String toString() {
-		return "Ladder [round=" + round + ", teamCode=" + teamCode + ", wins=" + wins + ", losses=" + losses
-				+ ", draws=" + draws + ", pointsFor=" + pointsFor + ", pointsAgainst=" + pointsAgainst + ", averageFor="
-				+ averageFor + ", averageAgainst=" + averageAgainst + ", pts=" + pts + ", percentage=" + percentage
-				+ ", displayName=" + displayName + ", teamUri=" + teamUri + "]";
-	}
 }

--- a/src/main/java/net/dflmngr/model/web/PlayerStats.java
+++ b/src/main/java/net/dflmngr/model/web/PlayerStats.java
@@ -1,7 +1,14 @@
 package net.dflmngr.model.web;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class PlayerStats {
-	
+
 	private int kicks;
 	private int handballs;
 	private int disposals;
@@ -16,144 +23,4 @@ public class PlayerStats {
 	private int predictedScore;
 	private int trend;
 	private String scrapingStatus;
-	
-	public PlayerStats() {}
-	
-	public PlayerStats(int kicks, int handballs, int disposals, int marks, int hitouts, int freesFor, int freesAgainst, 
-			           int tackles, int goals, int behinds, int score, int predictedScore, int trend, String scrapingStatus) {
-		this.kicks = kicks;
-		this.handballs = handballs;
-		this.disposals = disposals;
-		this.marks = marks;
-		this.hitouts = hitouts;
-		this.freesFor = freesFor;
-		this.freesAgainst = freesAgainst;
-		this.tackles = tackles;
-		this.goals = goals;
-		this.behinds = behinds;
-		this.score = score;
-		this.predictedScore = predictedScore;
-		this.trend = trend;
-		this.scrapingStatus = scrapingStatus;
-	}
-
-	public int getKicks() {
-		return kicks;
-	}
-
-	public void setKicks(int kicks) {
-		this.kicks = kicks;
-	}
-
-	public int getHandballs() {
-		return handballs;
-	}
-
-	public void setHandballs(int handballs) {
-		this.handballs = handballs;
-	}
-
-	public int getDisposals() {
-		return disposals;
-	}
-
-	public void setDisposals(int disposals) {
-		this.disposals = disposals;
-	}
-
-	public int getMarks() {
-		return marks;
-	}
-
-	public void setMarks(int marks) {
-		this.marks = marks;
-	}
-
-	public int getHitouts() {
-		return hitouts;
-	}
-
-	public void setHitouts(int hitouts) {
-		this.hitouts = hitouts;
-	}
-
-	public int getFreesFor() {
-		return freesFor;
-	}
-
-	public void setFreesFor(int freesFor) {
-		this.freesFor = freesFor;
-	}
-
-	public int getFreesAgainst() {
-		return freesAgainst;
-	}
-
-	public void setFreesAgainst(int freesAgainst) {
-		this.freesAgainst = freesAgainst;
-	}
-
-	public int getTackles() {
-		return tackles;
-	}
-
-	public void setTackles(int tackles) {
-		this.tackles = tackles;
-	}
-
-	public int getGoals() {
-		return goals;
-	}
-
-	public void setGoals(int goals) {
-		this.goals = goals;
-	}
-
-	public int getBehinds() {
-		return behinds;
-	}
-
-	public void setBehinds(int behinds) {
-		this.behinds = behinds;
-	}
-
-	public int getScore() {
-		return score;
-	}
-
-	public void setScore(int score) {
-		this.score = score;
-	}
-
-	public int getPredictedScore() {
-		return predictedScore;
-	}
-
-	public void setPredictedScore(int predictedScore) {
-		this.predictedScore = predictedScore;
-	}
-	public int getTrend() {
-		return trend;
-	}
-
-	public void setTrend(int trend) {
-		this.trend = trend;
-	}
-
-	public String getScrapingStatus() {
-		return scrapingStatus;
-	}
-
-	public void setScrapingStatus(String scrapingStatus) {
-		this.scrapingStatus = scrapingStatus;
-	}
-
-	@Override
-	public String toString() {
-		return "PlayerStats [kicks=" + kicks + ", handballs=" + handballs + ", disposals=" + disposals + ", marks="
-				+ marks + ", hitouts=" + hitouts + ", freesFor=" + freesFor + ", freesAgainst=" + freesAgainst
-				+ ", tackles=" + tackles + ", goals=" + goals + ", behinds=" + behinds + ", score=" + score
-				+ ", predictedScore=" + predictedScore + ", trend=" + trend + ", scrapingStatus=" + scrapingStatus
-				+ "]";
-	}
 }

--- a/src/main/java/net/dflmngr/model/web/Results.java
+++ b/src/main/java/net/dflmngr/model/web/Results.java
@@ -1,55 +1,16 @@
 package net.dflmngr.model.web;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class Results {
-	
+
 	private int round;
 	private int game;
 	private TeamResults homeTeam;
 	private TeamResults awayTeam;
-	
-	public Results() {}
-	
-	public Results(int round, int game, TeamResults homeTeam, TeamResults awayTeam) {
-		this.round = round;
-		this.game = game;
-		this.homeTeam = homeTeam;
-		this.awayTeam = awayTeam;
-	}
-
-	public int getRound() {
-		return round;
-	}
-
-	public void setRound(int round) {
-		this.round = round;
-	}
-
-	public int getGame() {
-		return game;
-	}
-
-	public void setGame(int game) {
-		this.game = game;
-	}
-
-	public TeamResults getHomeTeam() {
-		return homeTeam;
-	}
-
-	public void setHomeTeam(TeamResults homeTeam) {
-		this.homeTeam = homeTeam;
-	}
-
-	public TeamResults getAwayTeam() {
-		return awayTeam;
-	}
-
-	public void setAwayTeam(TeamResults awayTeam) {
-		this.awayTeam = awayTeam;
-	}
-
-	@Override
-	public String toString() {
-		return "Results [round=" + round + ", game=" + game + ", homeTeam=" + homeTeam + ", awayTeam=" + awayTeam + "]";
-	}
 }

--- a/src/main/java/net/dflmngr/model/web/RoundFixtures.java
+++ b/src/main/java/net/dflmngr/model/web/RoundFixtures.java
@@ -1,34 +1,15 @@
 package net.dflmngr.model.web;
 
 import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class RoundFixtures {
-	
+
 	private int round;
 	private List<GameFixture> games;
-	
-	public RoundFixtures() {}
-	
-	public RoundFixtures(int round, List<GameFixture> games) {
-		this.round = round;
-		this.games = games;
-	}
-	
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public List<GameFixture> getGames() {
-		return games;
-	}
-	public void setGames(List<GameFixture> games) {
-		this.games = games;
-	}
-
-	@Override
-	public String toString() {
-		return "RoundFixtures [round=" + round + ", games=" + games + "]";
-	}
 }

--- a/src/main/java/net/dflmngr/model/web/RoundMenu.java
+++ b/src/main/java/net/dflmngr/model/web/RoundMenu.java
@@ -1,42 +1,16 @@
 package net.dflmngr.model.web;
 
 import java.util.List;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class RoundMenu {
-	
+
 	private int round;
 	private List<GameMenu> games;
 	private boolean active;
-	
-	public RoundMenu() {}
-	
-	public RoundMenu(int round, List<GameMenu> games, boolean active) {
-		this.round = round;
-		this.games = games;
-		this.active = active;
-	}
-	
-	public int getRound() {
-		return round;
-	}
-	public void setRound(int round) {
-		this.round = round;
-	}
-	public List<GameMenu> getGames() {
-		return games;
-	}
-	public void setGames(List<GameMenu> games) {
-		this.games = games;
-	}
-	public boolean isActive() {
-		return active;
-	}
-	public void setActive(boolean active) {
-		this.active = active;
-	}
-
-	@Override
-	public String toString() {
-		return "RoundMenu [round=" + round + ", games=" + games + "]";
-	}
 }

--- a/src/main/java/net/dflmngr/model/web/SelectedPlayer.java
+++ b/src/main/java/net/dflmngr/model/web/SelectedPlayer.java
@@ -1,7 +1,14 @@
 package net.dflmngr.model.web;
 
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class SelectedPlayer {
-	
+
 	private int playerId;
 	private int teamPlayerId;
 	private String name;
@@ -12,89 +19,4 @@ public class SelectedPlayer {
 	private String replacementInd;
 	private int emgSort;
 	private PlayerStats stats;
-		
-	public SelectedPlayer() {}
-
-	public SelectedPlayer(int playerId, int teamPlayerId, String name, String position, boolean hasPlayer,
-			boolean scoreUsed, boolean isDnp, String replacementInd, int emgSort, PlayerStats stats) {
-		super();
-		this.playerId = playerId;
-		this.teamPlayerId = teamPlayerId;
-		this.name = name;
-		this.position = position;
-		this.hasPlayer = hasPlayer;
-		this.scoreUsed = scoreUsed;
-		this.isDnp = isDnp;
-		this.replacementInd = replacementInd;
-		this.emgSort = emgSort;
-		this.stats = stats;
-	}
-
-	public int getPlayerId() {
-		return playerId;
-	}
-	public void setPlayerId(int playerId) {
-		this.playerId = playerId;
-	}
-	public int getTeamPlayerId() {
-		return teamPlayerId;
-	}
-	public void setTeamPlayerId(int teamPlayerId) {
-		this.teamPlayerId = teamPlayerId;
-	}
-	public String getName() {
-		return name;
-	}
-	public void setName(String name) {
-		this.name = name;
-	}
-	public String getPosition() {
-		return position;
-	}
-	public void setPosition(String position) {
-		this.position = position;
-	}
-	public boolean hasPlayer() {
-		return hasPlayer;
-	}
-	public void setHasPlayer(boolean hasPlayer) {
-		this.hasPlayer = hasPlayer;
-	}
-	public boolean scoreUsed() {
-		return scoreUsed;
-	}
-	public void setScoreUsed(boolean scoreUsed) {
-		this.scoreUsed = scoreUsed;
-	}
-	public boolean isDnp() {
-		return isDnp;
-	}
-	public void setDnp(boolean isDnp) {
-		this.isDnp = isDnp;
-	}
-	public String getReplacementInd() {
-		return replacementInd;
-	}
-	public void setReplacementInd(String replacementInd) {
-		this.replacementInd = replacementInd;
-	}
-	public int getEmgSort() {
-		return emgSort;
-	}
-	public void setEmgSort(int emgSort) {
-		this.emgSort = emgSort;
-	}
-	public PlayerStats getStats() {
-		return stats;
-	}
-	public void setStats(PlayerStats stats) {
-		this.stats = stats;
-	}
-
-	@Override
-	public String toString() {
-		return "SelectedPlayer [playerId=" + playerId + ", teamPlayerId=" + teamPlayerId + ", name=" + name
-				+ ", position=" + position + ", hasPlayer=" + hasPlayer + ", scoreUsed=" + scoreUsed + ", isDnp="
-				+ isDnp + ", replacementInd=" + replacementInd + ", emgSort=" + emgSort + ", stats=" + stats + "]";
-	}
 }

--- a/src/main/java/net/dflmngr/model/web/TeamResults.java
+++ b/src/main/java/net/dflmngr/model/web/TeamResults.java
@@ -1,7 +1,9 @@
 package net.dflmngr.model.web;
 
 import java.util.List;
+import lombok.Data;
 
+@Data
 public class TeamResults {
 
 	private String teamCode;
@@ -13,68 +15,4 @@ public class TeamResults {
 	private int predictedScore;
 	private int trend;
 	private String emgInd;
-	
-	public String getTeamCode() {
-		return teamCode;
-	}
-	public void setTeamCode(String teamCode) {
-		this.teamCode = teamCode;
-	}
-	public String getTeamName() {
-		return teamName;
-	}
-	public void setTeamName(String teamName) {
-		this.teamName = teamName;
-	}
-	public List<SelectedPlayer> getPlayers() {
-		return players;
-	}
-	public void setPlayers(List<SelectedPlayer> players) {
-		this.players = players;
-	}
-	public List<SelectedPlayer> getEmergencies() {
-		return emergencies;
-	}
-	public void setEmergencies(List<SelectedPlayer> emergencies) {
-		this.emergencies = emergencies;
-	}
-	public int getScore() {
-		return score;
-	}
-	public void setScore(int score) {
-		this.score = score;
-	}
-	public int getCurrentPredictedScore() {
-		return currentPredictedScore;
-	}
-	public void setCurrentPredictedScore(int currentPredictedScore) {
-		this.currentPredictedScore = currentPredictedScore;
-	}
-
-	public int getPredictedScore() {
-		return predictedScore;
-	}
-	public void setPredictedScore(int predictedScore) {
-		this.predictedScore = predictedScore;
-	}
-	public int getTrend() {
-		return trend;
-	}
-	public void setTrend(int trend) {
-		this.trend = trend;
-	}
-	public String getEmgInd() {
-		return emgInd;
-	}
-	public void setEmgInd(String emgInd) {
-		this.emgInd = emgInd;
-	}
-
-	@Override
-	public String toString() {
-		return "TeamResults [teamCode=" + teamCode + ", teamName=" + teamName + ", players=" + players
-				+ ", emergencies=" + emergencies + ", score=" + score + ", currentPredictedScore="
-				+ currentPredictedScore + ", predictedScore=" + predictedScore + ", trend=" + trend + ", emgInd="
-				+ emgInd + "]";
-	}
 }


### PR DESCRIPTION
## Summary
- Add `lombok` dependency to `pom.xml`
- Replace manual getters/setters/toString/hashCode/equals with `@Data` on all 8 PK key classes
- Replace manual accessors with `@Getter @Setter @ToString @EqualsAndHashCode` on 12 entity classes
- Replace manual accessors with `@Data @NoArgsConstructor @AllArgsConstructor` on 9 web model classes
- Net result: -2,086 lines of boilerplate removed

## Preserved custom logic
- `DflLadder`, `DflPlayerScores`, `DflPlayerPredictedScores`: custom `compareTo`/`compare` methods kept
- `DflSelectedPlayer`: non-standard `isEmergency()`/`setEmergency()`/`hasPlayed()` accessors kept
- `DflPlayer`: non-standard `isFirstYear()`/`setFirstYear()` boolean accessor kept

## Test plan
- [x] All 41 unit tests pass locally
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)