### PR TITLE
Remove Heroku-specific files

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: java -jar target/dflmngr-online-1.0-SNAPSHOT.jar

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,0 @@
-java.runtime.version=17


### PR DESCRIPTION
## Summary
- Remove `Procfile` and `system.properties` — service no longer runs on Heroku