### PR TITLE
Fix HTTPS check to use startsWith instead of indexOf

### DIFF
--- a/src/main/java/net/dflmngr/servlet/filters/HttpsEnforcer.java
+++ b/src/main/java/net/dflmngr/servlet/filters/HttpsEnforcer.java
@@ -32,7 +32,7 @@ public class HttpsEnforcer implements Filter {
         HttpServletResponse response = (HttpServletResponse) servletResponse;
 
         if (request.getHeader(X_FORWARDED_PROTO) != null) {
-            if (request.getHeader(X_FORWARDED_PROTO).indexOf("https") != 0) {
+            if (!request.getHeader(X_FORWARDED_PROTO).startsWith("https")) {
                 response.sendRedirect("https://" + request.getServerName() + (request.getPathInfo() == null ? "" : request.getPathInfo()));
                 return;
             }

--- a/src/main/java/net/dflmngr/servlet/filters/HttpsEnforcer.java
+++ b/src/main/java/net/dflmngr/servlet/filters/HttpsEnforcer.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
@@ -23,9 +22,6 @@ public class HttpsEnforcer implements Filter {
     public static final String X_FORWARDED_PROTO = "x-forwarded-proto";
 
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {}
-
-    @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
 
         HttpServletRequest request = (HttpServletRequest) servletRequest;
@@ -40,8 +36,5 @@ public class HttpsEnforcer implements Filter {
 
         filterChain.doFilter(request, response);
     }
-
-    @Override
-    public void destroy() {}
 }
 

--- a/src/main/java/net/dflmngr/servlet/filters/HttpsEnforcer.java
+++ b/src/main/java/net/dflmngr/servlet/filters/HttpsEnforcer.java
@@ -27,14 +27,12 @@ public class HttpsEnforcer implements Filter {
         HttpServletRequest request = (HttpServletRequest) servletRequest;
         HttpServletResponse response = (HttpServletResponse) servletResponse;
 
-        if (request.getHeader(X_FORWARDED_PROTO) != null) {
-            if (!request.getHeader(X_FORWARDED_PROTO).startsWith("https")) {
-                response.sendRedirect("https://" + request.getServerName() + (request.getPathInfo() == null ? "" : request.getPathInfo()));
-                return;
-            }
+        String proto = request.getHeader(X_FORWARDED_PROTO);
+        if (proto != null && !proto.startsWith("https")) {
+            response.sendRedirect("https://" + request.getServerName() + (request.getPathInfo() == null ? "" : request.getPathInfo()));
+            return;
         }
 
         filterChain.doFilter(request, response);
     }
 }
-


### PR DESCRIPTION
Replace `indexOf("https") != 0` with `!startsWith("https")` in HttpsEnforcer.