### PR TITLE
Switch to OTEL Java agent for logging, drop direct Loki dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,25 @@ RUN mvn clean package -DskipTests -q
 FROM eclipse-temurin:21-jre-jammy
 RUN useradd -r -u 1001 -g root appuser
 WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget -q "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.25.0/opentelemetry-javaagent.jar" \
+        -O /app/opentelemetry-javaagent.jar && \
+    apt-get remove -y wget && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY --from=build_step /build/target/dflmngr-online-1.0-SNAPSHOT.jar app.jar
+
+ENV OTEL_SERVICE_NAME=dfl-manager-online
+ENV OTEL_LOGS_EXPORTER=none
+ENV OTEL_METRICS_EXPORTER=none
+ENV OTEL_TRACES_EXPORTER=none
+ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
 USER appuser
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+CMD ["sh", "-c", \
+     "BASE_ATTRS=\"app.name=dfl-manager-online,service.instance.id=${RENDER_INSTANCE_ID:-local},deployment.environment=${ENV:-local}\"; \
+      export OTEL_RESOURCE_ATTRIBUTES=\"${OTEL_RESOURCE_ATTRIBUTES:+${OTEL_RESOURCE_ATTRIBUTES},}${BASE_ATTRS}\"; \
+      exec java -javaagent:/app/opentelemetry-javaagent.jar -jar /app/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -52,15 +52,6 @@
 			<artifactId>commons-collections4</artifactId>
 			<version>4.5.0</version>
 		</dependency>
-		<dependency>
-			<groupId>com.github.loki4j</groupId>
-			<artifactId>loki-logback-appender</artifactId>
-			<version>1.5.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.codehaus.janino</groupId>
-			<artifactId>janino</artifactId>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,32 +8,8 @@
 
     <springProperty name="logLevel" source="logging.level.net.dflmngr" defaultValue="info"/>
 
-    <if condition='isDefined("LOKI_URL")'>
-        <then>
-            <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-                <http>
-                    <url>${LOKI_URL}/loki/api/v1/push</url>
-                </http>
-                <format>
-                    <label>
-                        <pattern>app=DFLManagerOnline,level=%level,handler=%logger{0}</pattern>
-                    </label>
-                    <message>
-                        <pattern>%p [%logger{0}] %m%n%ex</pattern>
-                    </message>
-                </format>
-            </appender>
-
-            <root level="${logLevel}">
-                <appender-ref ref="STDOUT"/>
-                <appender-ref ref="LOKI"/>
-            </root>
-        </then>
-        <else>
-            <root level="${logLevel}">
-                <appender-ref ref="STDOUT"/>
-            </root>
-        </else>
-    </if>
+    <root level="${logLevel}">
+        <appender-ref ref="STDOUT"/>
+    </root>
 
 </configuration>


### PR DESCRIPTION
## Summary
- Remove `loki-logback-appender` and `janino` dependencies from `pom.xml`
- Simplify `logback-spring.xml` to stdout only — OTEL agent handles log export
- Add OTEL Java agent (`opentelemetry-javaagent.jar` v2.25.0) to Dockerfile
- Set default OTEL exporters to `none` in Dockerfile (overridden at runtime)
- Add dynamic `OTEL_RESOURCE_ATTRIBUTES` with `app.name`, `service.instance.id`, `deployment.environment`

## Environment variables
- `OTEL_LOGS_EXPORTER=otlp` — enable log export
- `OTEL_EXPORTER_OTLP_ENDPOINT` — collector endpoint
- `OTEL_EXPORTER_OTLP_HEADERS` — auth headers if needed
- `OTEL_RESOURCE_ATTRIBUTES` — merged with base attributes at startup