### PR TITLE
Fix webmanifest 404 by correcting path to /favicon/site.webmanifest

### DIFF
--- a/src/main/resources/templates/fixtures.html
+++ b/src/main/resources/templates/fixtures.html
@@ -6,7 +6,7 @@
 	<link rel="apple-touch-icon" sizes="180x180" href="../../../static/favicon/apple-touch-icon.png" th:href="@{/static/favicon/apple-touch-icon.png}"/>
     <link rel="icon" type="image/png" sizes="32x32" href="../../../static/favicon/favicon-32x32.png" th:href="@{/static/favicon/favicon-32x32.png}"/>
     <link rel="icon" type="image/png" sizes="16x16" href="../../../static/favicon/favicon-16x16.png" th:href="@{/static/favicon/favicon-16x16.png}"/>
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="manifest" href="/favicon/site.webmanifest">
     <link rel="stylesheet" href="../../../static/css/bootstrap-3.3.7.min.css" th:href="@{/static/css/bootstrap-3.3.7.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/datatables-1.10.16.min.css" th:href="@{/static/css/datatables-1.10.16.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/styles.css" th:href="@{/static/css/styles.css}" type="text/css" media="screen"/>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -5,7 +5,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="../../../static/favicon/apple-touch-icon.png" th:href="@{/static/favicon/apple-touch-icon.png}"/>
     <link rel="icon" type="image/png" sizes="32x32" href="../../../static/favicon/favicon-32x32.png" th:href="@{/static/favicon/favicon-32x32.png}"/>
     <link rel="icon" type="image/png" sizes="16x16" href="../../../static/favicon/favicon-16x16.png" th:href="@{/static/favicon/favicon-16x16.png}"/>
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="manifest" href="/favicon/site.webmanifest">
 </head>
 <body>
 <nav class="navbar navbar-default navbar-fixed-top" th:fragment="header">

--- a/src/main/resources/templates/ladder.html
+++ b/src/main/resources/templates/ladder.html
@@ -6,7 +6,7 @@
 	<link rel="apple-touch-icon" sizes="180x180" href="../../../static/favicon/apple-touch-icon.png" th:href="@{/static/favicon/apple-touch-icon.png}"/>
     <link rel="icon" type="image/png" sizes="32x32" href="../../../static/favicon/favicon-32x32.png" th:href="@{/static/favicon/favicon-32x32.png}"/>
     <link rel="icon" type="image/png" sizes="16x16" href="../../../static/favicon/favicon-16x16.png" th:href="@{/static/favicon/favicon-16x16.png}"/>
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="manifest" href="/favicon/site.webmanifest">
     <link rel="stylesheet" href="../../../static/css/bootstrap-3.3.7.min.css" th:href="@{/static/css/bootstrap-3.3.7.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/datatables-1.10.16.min.css" th:href="@{/static/css/datatables-1.10.16.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/styles.css" th:href="@{/static/css/styles.css}" type="text/css" media="screen"/>

--- a/src/main/resources/templates/results.html
+++ b/src/main/resources/templates/results.html
@@ -7,7 +7,7 @@
 	<link rel="apple-touch-icon" sizes="180x180" href="../../../static/favicon/apple-touch-icon.png" th:href="@{/static/favicon/apple-touch-icon.png}"/>
     <link rel="icon" type="image/png" sizes="32x32" href="../../../static/favicon/favicon-32x32.png" th:href="@{/static/favicon/favicon-32x32.png}"/>
     <link rel="icon" type="image/png" sizes="16x16" href="../../../static/favicon/favicon-16x16.png" th:href="@{/static/favicon/favicon-16x16.png}"/>
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="manifest" href="/favicon/site.webmanifest">
     <link rel="stylesheet" href="../../../static/css/bootstrap-3.3.7.min.css" th:href="@{/static/css/bootstrap-3.3.7.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/datatables-1.10.16.min.css" th:href="@{/static/css/datatables-1.10.16.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/styles.css" th:href="@{/static/css/styles.css}" type="text/css" media="screen"/>


### PR DESCRIPTION
Fix 404s on `/site.webmanifest` — file is located at `/favicon/site.webmanifest` so update all template references accordingly.