### PR TITLE
Fix webmanifest and icon paths to use /static/favicon/ prefix

### DIFF
--- a/src/main/resources/static/favicon/site.webmanifest
+++ b/src/main/resources/static/favicon/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"","short_name":"","icons":[{"src":"/static/favicon/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/static/favicon/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}

--- a/src/main/resources/templates/fixtures.html
+++ b/src/main/resources/templates/fixtures.html
@@ -6,7 +6,7 @@
 	<link rel="apple-touch-icon" sizes="180x180" href="../../../static/favicon/apple-touch-icon.png" th:href="@{/static/favicon/apple-touch-icon.png}"/>
     <link rel="icon" type="image/png" sizes="32x32" href="../../../static/favicon/favicon-32x32.png" th:href="@{/static/favicon/favicon-32x32.png}"/>
     <link rel="icon" type="image/png" sizes="16x16" href="../../../static/favicon/favicon-16x16.png" th:href="@{/static/favicon/favicon-16x16.png}"/>
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="manifest" href="/static/favicon/site.webmanifest">
     <link rel="stylesheet" href="../../../static/css/bootstrap-3.3.7.min.css" th:href="@{/static/css/bootstrap-3.3.7.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/datatables-1.10.16.min.css" th:href="@{/static/css/datatables-1.10.16.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/styles.css" th:href="@{/static/css/styles.css}" type="text/css" media="screen"/>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -5,7 +5,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="../../../static/favicon/apple-touch-icon.png" th:href="@{/static/favicon/apple-touch-icon.png}"/>
     <link rel="icon" type="image/png" sizes="32x32" href="../../../static/favicon/favicon-32x32.png" th:href="@{/static/favicon/favicon-32x32.png}"/>
     <link rel="icon" type="image/png" sizes="16x16" href="../../../static/favicon/favicon-16x16.png" th:href="@{/static/favicon/favicon-16x16.png}"/>
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="manifest" href="/static/favicon/site.webmanifest">
 </head>
 <body>
 <nav class="navbar navbar-default navbar-fixed-top" th:fragment="header">

--- a/src/main/resources/templates/ladder.html
+++ b/src/main/resources/templates/ladder.html
@@ -6,7 +6,7 @@
 	<link rel="apple-touch-icon" sizes="180x180" href="../../../static/favicon/apple-touch-icon.png" th:href="@{/static/favicon/apple-touch-icon.png}"/>
     <link rel="icon" type="image/png" sizes="32x32" href="../../../static/favicon/favicon-32x32.png" th:href="@{/static/favicon/favicon-32x32.png}"/>
     <link rel="icon" type="image/png" sizes="16x16" href="../../../static/favicon/favicon-16x16.png" th:href="@{/static/favicon/favicon-16x16.png}"/>
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="manifest" href="/static/favicon/site.webmanifest">
     <link rel="stylesheet" href="../../../static/css/bootstrap-3.3.7.min.css" th:href="@{/static/css/bootstrap-3.3.7.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/datatables-1.10.16.min.css" th:href="@{/static/css/datatables-1.10.16.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/styles.css" th:href="@{/static/css/styles.css}" type="text/css" media="screen"/>

--- a/src/main/resources/templates/results.html
+++ b/src/main/resources/templates/results.html
@@ -7,7 +7,7 @@
 	<link rel="apple-touch-icon" sizes="180x180" href="../../../static/favicon/apple-touch-icon.png" th:href="@{/static/favicon/apple-touch-icon.png}"/>
     <link rel="icon" type="image/png" sizes="32x32" href="../../../static/favicon/favicon-32x32.png" th:href="@{/static/favicon/favicon-32x32.png}"/>
     <link rel="icon" type="image/png" sizes="16x16" href="../../../static/favicon/favicon-16x16.png" th:href="@{/static/favicon/favicon-16x16.png}"/>
-    <link rel="manifest" href="/favicon/site.webmanifest">
+    <link rel="manifest" href="/static/favicon/site.webmanifest">
     <link rel="stylesheet" href="../../../static/css/bootstrap-3.3.7.min.css" th:href="@{/static/css/bootstrap-3.3.7.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/datatables-1.10.16.min.css" th:href="@{/static/css/datatables-1.10.16.min.css}" type="text/css" media="screen"/>
 	<link rel="stylesheet" href="../../../static/css/styles.css" th:href="@{/static/css/styles.css}" type="text/css" media="screen"/>


### PR DESCRIPTION
## Summary
- Update webmanifest link in all 4 templates from `/favicon/site.webmanifest` to `/static/favicon/site.webmanifest`
- Fix icon paths in `site.webmanifest` from `/android-chrome-*.png` to `/static/favicon/android-chrome-*.png`

Resolves 404s on the webmanifest — static files are served under the `/static/` prefix.