### PR TITLE
Fix N+1 queries in ResultService

### DIFF
--- a/src/main/java/net/dflmngr/repositories/AflPlayerRepository.java
+++ b/src/main/java/net/dflmngr/repositories/AflPlayerRepository.java
@@ -1,9 +1,12 @@
 package net.dflmngr.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.dflmngr.model.entities.AflPlayer;
 
 public interface AflPlayerRepository extends JpaRepository<AflPlayer, String>{
 	AflPlayer findByDflPlayerId(Integer playerId);
+	List<AflPlayer> findByDflPlayerIdIn(List<Integer> playerIds);
 }

--- a/src/main/java/net/dflmngr/repositories/DflPlayerPredictedScoresRepository.java
+++ b/src/main/java/net/dflmngr/repositories/DflPlayerPredictedScoresRepository.java
@@ -1,8 +1,12 @@
 package net.dflmngr.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.dflmngr.model.entities.DflPlayerPredictedScores;
 import net.dflmngr.model.entities.keys.DflPlayerPredictedScoresPK;
 
-public interface DflPlayerPredictedScoresRepository extends JpaRepository<DflPlayerPredictedScores, DflPlayerPredictedScoresPK> {}
+public interface DflPlayerPredictedScoresRepository extends JpaRepository<DflPlayerPredictedScores, DflPlayerPredictedScoresPK> {
+	List<DflPlayerPredictedScores> findByRoundAndPlayerIdIn(int round, List<Integer> playerIds);
+}

--- a/src/main/java/net/dflmngr/repositories/DflPlayerScoresRepository.java
+++ b/src/main/java/net/dflmngr/repositories/DflPlayerScoresRepository.java
@@ -1,8 +1,12 @@
 package net.dflmngr.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.dflmngr.model.entities.DflPlayerScores;
 import net.dflmngr.model.entities.keys.DflPlayerScoresPK;
 
-public interface DflPlayerScoresRepository extends JpaRepository<DflPlayerScores, DflPlayerScoresPK> {}
+public interface DflPlayerScoresRepository extends JpaRepository<DflPlayerScores, DflPlayerScoresPK> {
+	List<DflPlayerScores> findByRoundAndPlayerIdIn(int round, List<Integer> playerIds);
+}

--- a/src/main/java/net/dflmngr/repositories/RawPlayerStatsRepository.java
+++ b/src/main/java/net/dflmngr/repositories/RawPlayerStatsRepository.java
@@ -1,5 +1,7 @@
 package net.dflmngr.repositories;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import net.dflmngr.model.entities.RawPlayerStats;
@@ -7,4 +9,5 @@ import net.dflmngr.model.entities.keys.RawPlayerStatsPK;
 
 public interface RawPlayerStatsRepository extends JpaRepository<RawPlayerStats, RawPlayerStatsPK> {
 	RawPlayerStats findByRoundAndTeamAndJumperNo(int round, String team, int jumperNo);
+	List<RawPlayerStats> findByRoundAndTeamIn(int round, List<String> teams);
 }

--- a/src/main/java/net/dflmngr/services/ResultService.java
+++ b/src/main/java/net/dflmngr/services/ResultService.java
@@ -3,8 +3,9 @@ package net.dflmngr.services;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -21,8 +22,6 @@ import net.dflmngr.model.entities.DflTeamScores;
 import net.dflmngr.model.entities.Globals;
 import net.dflmngr.model.entities.RawPlayerStats;
 import net.dflmngr.model.entities.keys.DflFixturePK;
-import net.dflmngr.model.entities.keys.DflPlayerPredictedScoresPK;
-import net.dflmngr.model.entities.keys.DflPlayerScoresPK;
 import net.dflmngr.model.entities.keys.DflTeamPredictedScoresPK;
 import net.dflmngr.model.entities.keys.DflTeamScoresPK;
 import net.dflmngr.model.entities.keys.GlobalsPK;
@@ -79,23 +78,68 @@ public class ResultService {
 	}
 	
 	public Results getResults(int round, int game) {
-		
+
 		Results results = new Results();
 		results.setRound(round);
 		results.setGame(game);
-		
+
 		try {
 			DflFixture dflFixture = getFixture(round, game);
 			String homeTeamCode = dflFixture.getHomeTeam();
 			String awayTeamCode = dflFixture.getAwayTeam();
 
-			results.setHomeTeam(getTeamResults(round, homeTeamCode));
-			results.setAwayTeam(getTeamResults(round, awayTeamCode));
+			List<DflSelectedPlayer> homeSelected = dflSelectedPlayerRepository.findByRoundAndTeamCode(round, homeTeamCode);
+			List<DflSelectedPlayer> awaySelected = dflSelectedPlayerRepository.findByRoundAndTeamCode(round, awayTeamCode);
+
+			List<DflSelectedPlayer> allSelected = new ArrayList<>();
+			allSelected.addAll(homeSelected);
+			allSelected.addAll(awaySelected);
+
+			RoundData roundData = loadRoundData(round, allSelected);
+
+			results.setHomeTeam(getTeamResults(round, homeTeamCode, homeSelected, roundData));
+			results.setAwayTeam(getTeamResults(round, awayTeamCode, awaySelected, roundData));
 		} catch (NoSuchElementException ex) {
 			logger.error("Fixture not found for round={} game={}", round, game, ex);
 		}
-			
+
 		return results;
+	}
+
+	private record RoundData(
+		Map<Integer, DflPlayer> dflPlayers,
+		Map<Integer, AflPlayer> aflPlayers,
+		Map<String, RawPlayerStats> rawStats,
+		Map<Integer, DflPlayerScores> playerScores,
+		Map<Integer, DflPlayerPredictedScores> predictedScores
+	) {}
+
+	private RoundData loadRoundData(int round, List<DflSelectedPlayer> allSelected) {
+		List<Integer> playerIds = allSelected.stream()
+			.map(DflSelectedPlayer::getPlayerId)
+			.collect(Collectors.toList());
+
+		Map<Integer, DflPlayer> dflPlayers = dflPlayerRepository.findByPlayerIdIn(playerIds).stream()
+			.collect(Collectors.toMap(DflPlayer::getPlayerId, p -> p));
+
+		List<AflPlayer> aflPlayerList = aflPlayerRepository.findByDflPlayerIdIn(playerIds);
+		Map<Integer, AflPlayer> aflPlayers = aflPlayerList.stream()
+			.collect(Collectors.toMap(AflPlayer::getDflPlayerId, p -> p));
+
+		List<String> aflTeamIds = aflPlayerList.stream()
+			.map(AflPlayer::getTeamId)
+			.distinct()
+			.collect(Collectors.toList());
+		Map<String, RawPlayerStats> rawStats = rawPlayerStatsRepository.findByRoundAndTeamIn(round, aflTeamIds).stream()
+			.collect(Collectors.toMap(s -> s.getTeam() + ":" + s.getJumperNo(), s -> s));
+
+		Map<Integer, DflPlayerScores> playerScores = dflPlayerScoresRepository.findByRoundAndPlayerIdIn(round, playerIds).stream()
+			.collect(Collectors.toMap(DflPlayerScores::getPlayerId, s -> s));
+
+		Map<Integer, DflPlayerPredictedScores> predictedScores = dflPlayerPredictedScoresRepository.findByRoundAndPlayerIdIn(round, playerIds).stream()
+			.collect(Collectors.toMap(DflPlayerPredictedScores::getPlayerId, s -> s));
+
+		return new RoundData(dflPlayers, aflPlayers, rawStats, playerScores, predictedScores);
 	}
 	
 	public Results getCurrentResults() {
@@ -175,10 +219,10 @@ public class ResultService {
 		return menu;
 	}
 	
-	private TeamResults getTeamResults(int round, String teamCode) {
-		
+	private TeamResults getTeamResults(int round, String teamCode, List<DflSelectedPlayer> selectedTeam, RoundData roundData) {
+
 		TeamResults teamResults = new TeamResults();
-		
+
 		if(teamCode != null) {
 			DflTeam team = dflTeamRepository.findById(teamCode).orElseThrow();
 			teamResults.setTeamCode(teamCode);
@@ -186,34 +230,34 @@ public class ResultService {
 
 			List<SelectedPlayer> players = new ArrayList<>();
 			List<SelectedPlayer> emergencies = new ArrayList<>();
-			
-			int currentPredictedScore = calculateTeamScore(round, teamCode, players, emergencies);
-			
+
+			int currentPredictedScore = calculateTeamScore(selectedTeam, players, emergencies, roundData);
+
 			teamResults.setPlayers(players);
-			
+
 			setEmgsInd(emergencies, teamResults);
-			
+
 			teamResults.setEmergencies(emergencies);
-			
+
 			DflTeamScoresPK dflTeamScoresPK = new DflTeamScoresPK();
 			dflTeamScoresPK.setRound(round);
 			dflTeamScoresPK.setTeamCode(teamCode);
 			DflTeamScores dflTeamScore = dflTeamScoresRepository.findById(dflTeamScoresPK).orElse(null);
-			
+
 			DflTeamPredictedScoresPK dflTeamPredictedScoresPK = new DflTeamPredictedScoresPK();
 			dflTeamPredictedScoresPK.setRound(round);
 			dflTeamPredictedScoresPK.setTeamCode(teamCode);
 			DflTeamPredictedScores dflTeamPredictedScore = dflTeamPredictedScoresRepository.findById(dflTeamPredictedScoresPK).orElseThrow();
-			
+
 			if(dflTeamScore != null) {
 				teamResults.setScore(dflTeamScore.getScore());
 			} else {
 				teamResults.setScore(0);
 			}
-			
+
 			teamResults.setCurrentPredictedScore(currentPredictedScore);
 			teamResults.setPredictedScore(dflTeamPredictedScore.getPredictedScore());
-			
+
 			int trend = 0;
 			if(currentPredictedScore == dflTeamPredictedScore.getPredictedScore()) {
 				trend = teamResults.getScore() - dflTeamPredictedScore.getPredictedScore();
@@ -222,17 +266,15 @@ public class ResultService {
 			}
 			teamResults.setTrend(trend);
 		}
-		
+
 		return teamResults;
 	}
 
-	private int calculateTeamScore(int round, String teamCode, List<SelectedPlayer> players, List<SelectedPlayer> emergencies) {
-		List<DflSelectedPlayer> selectedTeam = dflSelectedPlayerRepository.findByRoundAndTeamCode(round, teamCode);
-
+	private int calculateTeamScore(List<DflSelectedPlayer> selectedTeam, List<SelectedPlayer> players, List<SelectedPlayer> emergencies, RoundData roundData) {
 		int currentPredictedScore = 0;
 		for(DflSelectedPlayer selectedPlayer : selectedTeam) {
 			if(selectedPlayer.isScoreUsed()) {
-				SelectedPlayer sp = getSelectedPlayer(selectedPlayer);
+				SelectedPlayer sp = getSelectedPlayer(selectedPlayer, roundData);
 				players.add(sp);
 				if(sp.isDnp()) {
 					currentPredictedScore = currentPredictedScore + 0;
@@ -244,33 +286,33 @@ public class ResultService {
 					}
 				}
 			} else {
-				emergencies.add(getSelectedPlayer(selectedPlayer));
+				emergencies.add(getSelectedPlayer(selectedPlayer, roundData));
 			}
 		}
 
 		return currentPredictedScore;
 	}
-	
-	private SelectedPlayer getSelectedPlayer(DflSelectedPlayer selectedPlayer) {
+
+	private SelectedPlayer getSelectedPlayer(DflSelectedPlayer selectedPlayer, RoundData roundData) {
 		SelectedPlayer sp = new SelectedPlayer();
-		
+
 		sp.setPlayerId(selectedPlayer.getPlayerId());
 		sp.setTeamPlayerId(selectedPlayer.getTeamPlayerId());
-		
-		DflPlayer player = dflPlayerRepository.findById(selectedPlayer.getPlayerId()).orElseThrow();
-		
+
+		DflPlayer player = roundData.dflPlayers().get(selectedPlayer.getPlayerId());
+
 		if(player.getInitial() == null || player.getInitial().isEmpty()) {
 			sp.setName(player.getFirstName() + " " + player.getLastName());
 		} else {
 			sp.setName(player.getFirstName() + " " + player.getInitial() + ". " + player.getLastName());
 		}
-		
+
 		sp.setPosition(player.getPosition());
 		sp.setHasPlayer(selectedPlayer.hasPlayed());
 		sp.setScoreUsed(selectedPlayer.isScoreUsed());
 		sp.setDnp(selectedPlayer.isDnp());
 		sp.setReplacementInd(selectedPlayer.getReplacementInd());
-		
+
 		if(selectedPlayer.getReplacementInd() != null && selectedPlayer.getReplacementInd().equals("*")) {
 			sp.setEmgSort(1);
 		} else if(selectedPlayer.getReplacementInd() != null && selectedPlayer.getReplacementInd().equals("**")) {
@@ -278,9 +320,9 @@ public class ResultService {
 		} else {
 			sp.setEmgSort(selectedPlayer.isEmergency());
 		}
-		
-		sp.setStats(getPlayerStats(selectedPlayer.getRound(), selectedPlayer.getPlayerId()));
-		
+
+		sp.setStats(getPlayerStats(selectedPlayer.getPlayerId(), roundData));
+
 		return sp;
 	}
 
@@ -309,45 +351,35 @@ public class ResultService {
 		}
 	}
 	
-	private PlayerStats getPlayerStats(int round, int playerId) {
+	private PlayerStats getPlayerStats(int playerId, RoundData roundData) {
 		PlayerStats playerStats = new PlayerStats();
-		
-		AflPlayer aflPlayer = aflPlayerRepository.findByDflPlayerId(playerId);
-				
-		RawPlayerStats rawPlayerStats = rawPlayerStatsRepository.findByRoundAndTeamAndJumperNo(round, aflPlayer.getTeamId(), aflPlayer.getJumperNo());
-		
-		if(rawPlayerStats != null) {
-			playerStats.setKicks(rawPlayerStats.getKicks());
-			playerStats.setHandballs(rawPlayerStats.getHandballs());
-			playerStats.setDisposals(rawPlayerStats.getDisposals());
-			playerStats.setMarks(rawPlayerStats.getMarks());
-			playerStats.setHitouts(rawPlayerStats.getHitouts());
-			playerStats.setFreesFor(rawPlayerStats.getFreesFor());
-			playerStats.setFreesAgainst(rawPlayerStats.getFreesAgainst());
-			playerStats.setTackles(rawPlayerStats.getTackles());
-			playerStats.setGoals(rawPlayerStats.getGoals());
-			playerStats.setBehinds(rawPlayerStats.getBehinds());
-			playerStats.setScrapingStatus(rawPlayerStats.getScrapingStatus());
+
+		AflPlayer aflPlayer = roundData.aflPlayers().get(playerId);
+		if(aflPlayer != null) {
+			RawPlayerStats rawPlayerStats = roundData.rawStats().get(aflPlayer.getTeamId() + ":" + aflPlayer.getJumperNo());
+			if(rawPlayerStats != null) {
+				playerStats.setKicks(rawPlayerStats.getKicks());
+				playerStats.setHandballs(rawPlayerStats.getHandballs());
+				playerStats.setDisposals(rawPlayerStats.getDisposals());
+				playerStats.setMarks(rawPlayerStats.getMarks());
+				playerStats.setHitouts(rawPlayerStats.getHitouts());
+				playerStats.setFreesFor(rawPlayerStats.getFreesFor());
+				playerStats.setFreesAgainst(rawPlayerStats.getFreesAgainst());
+				playerStats.setTackles(rawPlayerStats.getTackles());
+				playerStats.setGoals(rawPlayerStats.getGoals());
+				playerStats.setBehinds(rawPlayerStats.getBehinds());
+				playerStats.setScrapingStatus(rawPlayerStats.getScrapingStatus());
+			}
 		}
-		
-		DflPlayerScoresPK dflPlayerScoresPK = new DflPlayerScoresPK();
-		dflPlayerScoresPK.setPlayerId(playerId);
-		dflPlayerScoresPK.setRound(round);
-		
-		DflPlayerScores dflPlayerScores = dflPlayerScoresRepository.findById(dflPlayerScoresPK).orElse(null);
-		
-		DflPlayerPredictedScoresPK dflPlayerPredictedScoresPK = new DflPlayerPredictedScoresPK();
-		dflPlayerPredictedScoresPK.setPlayerId(playerId);
-		dflPlayerPredictedScoresPK.setRound(round);
-		
-		Optional<DflPlayerPredictedScores> dflPlayerPredictedScores = dflPlayerPredictedScoresRepository.findById(dflPlayerPredictedScoresPK);
-		
-		if(dflPlayerPredictedScores.isPresent()) {
-			playerStats.setPredictedScore(dflPlayerPredictedScores.get().getPredictedScore());
+
+		DflPlayerPredictedScores predictedScores = roundData.predictedScores().get(playerId);
+		if(predictedScores != null) {
+			playerStats.setPredictedScore(predictedScores.getPredictedScore());
 		} else {
 			playerStats.setPredictedScore(25);
 		}
-		
+
+		DflPlayerScores dflPlayerScores = roundData.playerScores().get(playerId);
 		int trend = 0;
 		if(dflPlayerScores != null) {
 			playerStats.setScore(dflPlayerScores.getScore());
@@ -355,9 +387,9 @@ public class ResultService {
 		} else {
 			trend = trend - playerStats.getPredictedScore();
 		}
-		
+
 		playerStats.setTrend(trend);
-		
+
 		return playerStats;
 	}
 		

--- a/src/main/java/net/dflmngr/services/ResultService.java
+++ b/src/main/java/net/dflmngr/services/ResultService.java
@@ -131,7 +131,7 @@ public class ResultService {
 			.distinct()
 			.collect(Collectors.toList());
 		Map<String, RawPlayerStats> rawStats = rawPlayerStatsRepository.findByRoundAndTeamIn(round, aflTeamIds).stream()
-			.collect(Collectors.toMap(s -> s.getTeam() + ":" + s.getJumperNo(), s -> s));
+			.collect(Collectors.toMap(s -> s.getTeam() + ":" + s.getJumperNo(), s -> s, (existing, replacement) -> existing));
 
 		Map<Integer, DflPlayerScores> playerScores = dflPlayerScoresRepository.findByRoundAndPlayerIdIn(round, playerIds).stream()
 			.collect(Collectors.toMap(DflPlayerScores::getPlayerId, s -> s));

--- a/src/test/java/net/dflmngr/services/ResultServiceTest.java
+++ b/src/test/java/net/dflmngr/services/ResultServiceTest.java
@@ -2,6 +2,8 @@ package net.dflmngr.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -27,8 +29,6 @@ import net.dflmngr.model.entities.DflTeamScores;
 import net.dflmngr.model.entities.Globals;
 import net.dflmngr.model.entities.RawPlayerStats;
 import net.dflmngr.model.entities.keys.DflFixturePK;
-import net.dflmngr.model.entities.keys.DflPlayerPredictedScoresPK;
-import net.dflmngr.model.entities.keys.DflPlayerScoresPK;
 import net.dflmngr.model.entities.keys.DflTeamPredictedScoresPK;
 import net.dflmngr.model.entities.keys.DflTeamScoresPK;
 import net.dflmngr.model.entities.keys.GlobalsPK;
@@ -158,11 +158,13 @@ class ResultServiceTest {
 
     private void stubPlayerForTeam(String teamCode) {
         when(dflSelectedPlayerRepository.findByRoundAndTeamCode(1, teamCode)).thenReturn(List.of(selectedPlayer));
-        when(dflPlayerRepository.findById(101)).thenReturn(Optional.of(player));
-        when(aflPlayerRepository.findByDflPlayerId(101)).thenReturn(aflPlayer);
-        when(rawPlayerStatsRepository.findByRoundAndTeamAndJumperNo(1, "RICH", 5)).thenReturn(rawStats);
-        when(dflPlayerScoresRepository.findById(any(DflPlayerScoresPK.class))).thenReturn(Optional.of(playerScores));
-        when(dflPlayerPredictedScoresRepository.findById(any(DflPlayerPredictedScoresPK.class))).thenReturn(Optional.of(playerPredictedScores));
+        when(dflPlayerRepository.findByPlayerIdIn(anyList())).thenReturn(List.of(player));
+        when(aflPlayerRepository.findByDflPlayerIdIn(anyList())).thenReturn(List.of(aflPlayer));
+        when(rawPlayerStatsRepository.findByRoundAndTeamIn(anyInt(), anyList())).thenReturn(List.of(rawStats));
+        rawStats.setTeam("RICH");
+        rawStats.setJumperNo(5);
+        when(dflPlayerScoresRepository.findByRoundAndPlayerIdIn(anyInt(), anyList())).thenReturn(List.of(playerScores));
+        when(dflPlayerPredictedScoresRepository.findByRoundAndPlayerIdIn(anyInt(), anyList())).thenReturn(List.of(playerPredictedScores));
     }
 
     @Test
@@ -297,11 +299,11 @@ class ResultServiceTest {
         stubFixtureAndTeams();
 
         when(dflSelectedPlayerRepository.findByRoundAndTeamCode(1, "AAA")).thenReturn(List.of(selectedPlayer));
-        when(dflPlayerRepository.findById(101)).thenReturn(Optional.of(player));
-        when(aflPlayerRepository.findByDflPlayerId(101)).thenReturn(aflPlayer);
-        when(rawPlayerStatsRepository.findByRoundAndTeamAndJumperNo(1, "RICH", 5)).thenReturn(null);
-        when(dflPlayerScoresRepository.findById(any(DflPlayerScoresPK.class))).thenReturn(Optional.empty());
-        when(dflPlayerPredictedScoresRepository.findById(any(DflPlayerPredictedScoresPK.class))).thenReturn(Optional.empty());
+        when(dflPlayerRepository.findByPlayerIdIn(anyList())).thenReturn(List.of(player));
+        when(aflPlayerRepository.findByDflPlayerIdIn(anyList())).thenReturn(List.of(aflPlayer));
+        when(rawPlayerStatsRepository.findByRoundAndTeamIn(anyInt(), anyList())).thenReturn(List.of());
+        when(dflPlayerScoresRepository.findByRoundAndPlayerIdIn(anyInt(), anyList())).thenReturn(List.of());
+        when(dflPlayerPredictedScoresRepository.findByRoundAndPlayerIdIn(anyInt(), anyList())).thenReturn(List.of());
 
         DflTeamPredictedScores awayPredicted = new DflTeamPredictedScores();
         awayPredicted.setRound(1);
@@ -340,11 +342,11 @@ class ResultServiceTest {
 
         stubFixtureAndTeams();
         when(dflSelectedPlayerRepository.findByRoundAndTeamCode(1, "AAA")).thenReturn(List.of(emg));
-        when(dflPlayerRepository.findById(202)).thenReturn(Optional.of(emgPlayer));
-        when(aflPlayerRepository.findByDflPlayerId(202)).thenReturn(emgAflPlayer);
-        when(rawPlayerStatsRepository.findByRoundAndTeamAndJumperNo(1, "MELB", 7)).thenReturn(null);
-        when(dflPlayerScoresRepository.findById(any(DflPlayerScoresPK.class))).thenReturn(Optional.empty());
-        when(dflPlayerPredictedScoresRepository.findById(any(DflPlayerPredictedScoresPK.class))).thenReturn(Optional.empty());
+        when(dflPlayerRepository.findByPlayerIdIn(anyList())).thenReturn(List.of(emgPlayer));
+        when(aflPlayerRepository.findByDflPlayerIdIn(anyList())).thenReturn(List.of(emgAflPlayer));
+        when(rawPlayerStatsRepository.findByRoundAndTeamIn(anyInt(), anyList())).thenReturn(List.of());
+        when(dflPlayerScoresRepository.findByRoundAndPlayerIdIn(anyInt(), anyList())).thenReturn(List.of());
+        when(dflPlayerPredictedScoresRepository.findByRoundAndPlayerIdIn(anyInt(), anyList())).thenReturn(List.of());
 
         DflTeamPredictedScores predicted = new DflTeamPredictedScores();
         predicted.setRound(1);
@@ -382,11 +384,11 @@ class ResultServiceTest {
 
         stubFixtureAndTeams();
         when(dflSelectedPlayerRepository.findByRoundAndTeamCode(1, "AAA")).thenReturn(List.of(emg));
-        when(dflPlayerRepository.findById(202)).thenReturn(Optional.of(emgPlayer));
-        when(aflPlayerRepository.findByDflPlayerId(202)).thenReturn(emgAflPlayer);
-        when(rawPlayerStatsRepository.findByRoundAndTeamAndJumperNo(1, "MELB", 7)).thenReturn(null);
-        when(dflPlayerScoresRepository.findById(any(DflPlayerScoresPK.class))).thenReturn(Optional.empty());
-        when(dflPlayerPredictedScoresRepository.findById(any(DflPlayerPredictedScoresPK.class))).thenReturn(Optional.empty());
+        when(dflPlayerRepository.findByPlayerIdIn(anyList())).thenReturn(List.of(emgPlayer));
+        when(aflPlayerRepository.findByDflPlayerIdIn(anyList())).thenReturn(List.of(emgAflPlayer));
+        when(rawPlayerStatsRepository.findByRoundAndTeamIn(anyInt(), anyList())).thenReturn(List.of());
+        when(dflPlayerScoresRepository.findByRoundAndPlayerIdIn(anyInt(), anyList())).thenReturn(List.of());
+        when(dflPlayerPredictedScoresRepository.findByRoundAndPlayerIdIn(anyInt(), anyList())).thenReturn(List.of());
 
         DflTeamPredictedScores predicted = new DflTeamPredictedScores();
         predicted.setRound(1);
@@ -423,11 +425,11 @@ class ResultServiceTest {
 
         stubFixtureAndTeams();
         when(dflSelectedPlayerRepository.findByRoundAndTeamCode(1, "AAA")).thenReturn(List.of(emg));
-        when(dflPlayerRepository.findById(202)).thenReturn(Optional.of(emgPlayer));
-        when(aflPlayerRepository.findByDflPlayerId(202)).thenReturn(emgAflPlayer);
-        when(rawPlayerStatsRepository.findByRoundAndTeamAndJumperNo(1, "MELB", 7)).thenReturn(null);
-        when(dflPlayerScoresRepository.findById(any(DflPlayerScoresPK.class))).thenReturn(Optional.empty());
-        when(dflPlayerPredictedScoresRepository.findById(any(DflPlayerPredictedScoresPK.class))).thenReturn(Optional.empty());
+        when(dflPlayerRepository.findByPlayerIdIn(anyList())).thenReturn(List.of(emgPlayer));
+        when(aflPlayerRepository.findByDflPlayerIdIn(anyList())).thenReturn(List.of(emgAflPlayer));
+        when(rawPlayerStatsRepository.findByRoundAndTeamIn(anyInt(), anyList())).thenReturn(List.of());
+        when(dflPlayerScoresRepository.findByRoundAndPlayerIdIn(anyInt(), anyList())).thenReturn(List.of());
+        when(dflPlayerPredictedScoresRepository.findByRoundAndPlayerIdIn(anyInt(), anyList())).thenReturn(List.of());
 
         DflTeamPredictedScores predicted = new DflTeamPredictedScores();
         predicted.setRound(1);


### PR DESCRIPTION
## Summary
- Added bulk query methods to `AflPlayerRepository`, `DflPlayerScoresRepository`, `DflPlayerPredictedScoresRepository`, and `RawPlayerStatsRepository`
- Refactored `ResultService` to fetch all player data for both teams in a fixed set of queries per request, then use in-memory maps for lookup
- Previously fired 4+ DB queries per player (176+ queries for a full match); now fires ~7 queries regardless of squad size