### PR TITLE
Set ENV=preview when IS_PULL_REQUEST is true

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
 COPY --from=build_step /build/target/dflmngr-online-1.0-SNAPSHOT.jar app.jar
 
 ARG IS_PULL_REQUEST=false
-ENV ENV_FROM_BUILD=${IS_PULL_REQUEST}
+ENV APP_ENV_FROM_BUILD=${IS_PULL_REQUEST}
 ENV OTEL_SERVICE_NAME=dfl-manager-online
 ENV OTEL_LOGS_EXPORTER=none
 ENV OTEL_METRICS_EXPORTER=none
@@ -29,7 +29,7 @@ ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 
 USER appuser
 CMD ["sh", "-c", \
-     "if [ \"${ENV_FROM_BUILD}\" = \"true\" ]; then export ENV=preview; fi; \
-      BASE_ATTRS=\"app.name=dfl-manager-online,service.instance.id=${RENDER_INSTANCE_ID:-local},deployment.environment=${ENV:-local}\"; \
+     "if [ \"${APP_ENV_FROM_BUILD}\" = \"true\" ]; then export APP_ENV=preview; fi; \
+      BASE_ATTRS=\"app.name=dfl-manager-online,service.instance.id=${RENDER_INSTANCE_ID:-local},deployment.environment=${APP_ENV:-local}\"; \
       export OTEL_RESOURCE_ATTRIBUTES=\"${OTEL_RESOURCE_ATTRIBUTES:+${OTEL_RESOURCE_ATTRIBUTES},}${BASE_ATTRS}\"; \
       exec java -javaagent:/app/opentelemetry-javaagent.jar -jar /app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && \
 
 COPY --from=build_step /build/target/dflmngr-online-1.0-SNAPSHOT.jar app.jar
 
+ARG IS_PULL_REQUEST=false
+ENV ENV_FROM_BUILD=${IS_PULL_REQUEST}
 ENV OTEL_SERVICE_NAME=dfl-manager-online
 ENV OTEL_LOGS_EXPORTER=none
 ENV OTEL_METRICS_EXPORTER=none
@@ -27,7 +29,7 @@ ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 
 USER appuser
 CMD ["sh", "-c", \
-     "if [ \"${IS_PULL_REQUEST:-false}\" = \"true\" ]; then export ENV=preview; fi; \
+     "if [ \"${ENV_FROM_BUILD}\" = \"true\" ]; then export ENV=preview; fi; \
       BASE_ATTRS=\"app.name=dfl-manager-online,service.instance.id=${RENDER_INSTANCE_ID:-local},deployment.environment=${ENV:-local}\"; \
       export OTEL_RESOURCE_ATTRIBUTES=\"${OTEL_RESOURCE_ATTRIBUTES:+${OTEL_RESOURCE_ATTRIBUTES},}${BASE_ATTRS}\"; \
       exec java -javaagent:/app/opentelemetry-javaagent.jar -jar /app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update && \
 COPY --from=build_step /build/target/dflmngr-online-1.0-SNAPSHOT.jar app.jar
 
 ARG IS_PULL_REQUEST=false
-ENV ENV_FROM_BUILD=${IS_PULL_REQUEST}
+ENV APP_ENV_FROM_BUILD=${IS_PULL_REQUEST}
+ENV APP_ENV=local
 ENV OTEL_SERVICE_NAME=dfl-manager-online
 ENV OTEL_LOGS_EXPORTER=none
 ENV OTEL_METRICS_EXPORTER=none
@@ -29,7 +30,7 @@ ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 
 USER appuser
 CMD ["sh", "-c", \
-     "if [ \"${ENV_FROM_BUILD}\" = \"true\" ]; then export ENV=preview; fi; \
-      BASE_ATTRS=\"app.name=dfl-manager-online,service.instance.id=${RENDER_INSTANCE_ID:-local},deployment.environment=${ENV:-local}\"; \
+     "if [ \"${APP_ENV_FROM_BUILD}\" = \"true\" ]; then export APP_ENV=preview; fi; \
+      BASE_ATTRS=\"app.name=dfl-manager-online,service.instance.id=${RENDER_INSTANCE_ID:-local},deployment.environment=${APP_ENV}\"; \
       export OTEL_RESOURCE_ATTRIBUTES=\"${OTEL_RESOURCE_ATTRIBUTES:+${OTEL_RESOURCE_ATTRIBUTES},}${BASE_ATTRS}\"; \
       exec java -javaagent:/app/opentelemetry-javaagent.jar -jar /app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
 COPY --from=build_step /build/target/dflmngr-online-1.0-SNAPSHOT.jar app.jar
 
 ARG IS_PULL_REQUEST=false
-ENV APP_ENV_FROM_BUILD=${IS_PULL_REQUEST}
+ENV ENV_FROM_BUILD=${IS_PULL_REQUEST}
 ENV OTEL_SERVICE_NAME=dfl-manager-online
 ENV OTEL_LOGS_EXPORTER=none
 ENV OTEL_METRICS_EXPORTER=none
@@ -29,7 +29,7 @@ ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 
 USER appuser
 CMD ["sh", "-c", \
-     "if [ \"${APP_ENV_FROM_BUILD}\" = \"true\" ]; then export APP_ENV=preview; fi; \
-      BASE_ATTRS=\"app.name=dfl-manager-online,service.instance.id=${RENDER_INSTANCE_ID:-local},deployment.environment=${APP_ENV:-local}\"; \
+     "if [ \"${ENV_FROM_BUILD}\" = \"true\" ]; then export ENV=preview; fi; \
+      BASE_ATTRS=\"app.name=dfl-manager-online,service.instance.id=${RENDER_INSTANCE_ID:-local},deployment.environment=${ENV:-local}\"; \
       export OTEL_RESOURCE_ATTRIBUTES=\"${OTEL_RESOURCE_ATTRIBUTES:+${OTEL_RESOURCE_ATTRIBUTES},}${BASE_ATTRS}\"; \
       exec java -javaagent:/app/opentelemetry-javaagent.jar -jar /app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 
 USER appuser
 CMD ["sh", "-c", \
-     "BASE_ATTRS=\"app.name=dfl-manager-online,service.instance.id=${RENDER_INSTANCE_ID:-local},deployment.environment=${ENV:-local}\"; \
+     "if [ \"${IS_PULL_REQUEST:-false}\" = \"true\" ]; then export ENV=preview; fi; \
+      BASE_ATTRS=\"app.name=dfl-manager-online,service.instance.id=${RENDER_INSTANCE_ID:-local},deployment.environment=${ENV:-local}\"; \
       export OTEL_RESOURCE_ATTRIBUTES=\"${OTEL_RESOURCE_ATTRIBUTES:+${OTEL_RESOURCE_ATTRIBUTES},}${BASE_ATTRS}\"; \
       exec java -javaagent:/app/opentelemetry-javaagent.jar -jar /app/app.jar"]


### PR DESCRIPTION
## Summary
- When `IS_PULL_REQUEST=true` (set by Render for PR preview deployments), `ENV` is overridden to `preview` before the app starts
- This flows through to the `deployment.environment` OTEL resource attribute, so preview deployments are tagged correctly in observability tooling