### PR TITLE
Disable JPA open-in-view

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 server:
   port: ${PORT:5001}
 spring:
+  jpa:
+    open-in-view: false
   datasource:
     url: ${JDBC_DATABASE_URL}
     username: ${JDBC_DATABASE_USERNAME}


### PR DESCRIPTION
## Summary
- Set `spring.jpa.open-in-view=false` to suppress the startup warning and prevent unintended DB queries being triggered during Thymeleaf view rendering