### PR TITLE
Fix HttpsEnforcer query string loss and rename GlobalsRespository typo

### DIFF
--- a/src/main/java/net/dflmngr/repositories/GlobalsRepository.java
+++ b/src/main/java/net/dflmngr/repositories/GlobalsRepository.java
@@ -5,4 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import net.dflmngr.model.entities.Globals;
 import net.dflmngr.model.entities.keys.GlobalsPK;
 
-public interface GlobalsRespository extends JpaRepository<Globals, GlobalsPK>  {}
+public interface GlobalsRepository extends JpaRepository<Globals, GlobalsPK>  {}

--- a/src/main/java/net/dflmngr/services/ResultService.java
+++ b/src/main/java/net/dflmngr/services/ResultService.java
@@ -40,7 +40,7 @@ import net.dflmngr.repositories.DflSelectedPlayerRepository;
 import net.dflmngr.repositories.DflTeamPredictedScoresRepository;
 import net.dflmngr.repositories.DflTeamRepository;
 import net.dflmngr.repositories.DflTeamScoresRepository;
-import net.dflmngr.repositories.GlobalsRespository;
+import net.dflmngr.repositories.GlobalsRepository;
 import net.dflmngr.repositories.RawPlayerStatsRepository;
 
 @Service
@@ -58,12 +58,12 @@ public class ResultService {
 	private final DflPlayerPredictedScoresRepository dflPlayerPredictedScoresRepository;
 	private final DflTeamScoresRepository dflTeamScoresRepository;
 	private final DflTeamPredictedScoresRepository dflTeamPredictedScoresRepository;
-	private final GlobalsRespository globalsRespository;
+	private final GlobalsRepository globalsRespository;
 	
 	public ResultService(DflFixtureRepository dflFixtureRepository, DflTeamRepository dflTeamRepository, DflPlayerRepository dflPlayerRepository, AflPlayerRepository aflPlayerRepository,
 			             DflSelectedPlayerRepository dflSelectedPlayerRepository, RawPlayerStatsRepository rawPlayerStatsRepository, DflPlayerScoresRepository dflPlayerScoresRepository,
 			             DflPlayerPredictedScoresRepository dflPlayerPredictedScoresRepository, DflTeamScoresRepository dflTeamScoresRepository,
-			             DflTeamPredictedScoresRepository dflTeamPredictedScoresRepository, GlobalsRespository globalsRespository) {
+			             DflTeamPredictedScoresRepository dflTeamPredictedScoresRepository, GlobalsRepository globalsRespository) {
 		this.dflFixtureRepository = dflFixtureRepository;
 		this.dflTeamRepository = dflTeamRepository;
 		this.dflPlayerRepository = dflPlayerRepository;

--- a/src/main/java/net/dflmngr/servlet/filters/HttpsEnforcer.java
+++ b/src/main/java/net/dflmngr/servlet/filters/HttpsEnforcer.java
@@ -29,7 +29,10 @@ public class HttpsEnforcer implements Filter {
 
         String proto = request.getHeader(X_FORWARDED_PROTO);
         if (proto != null && !proto.startsWith("https")) {
-            response.sendRedirect("https://" + request.getServerName() + (request.getPathInfo() == null ? "" : request.getPathInfo()));
+            String path = request.getRequestURI();
+            String query = request.getQueryString();
+            String redirectUrl = "https://" + request.getServerName() + path + (query != null ? "?" + query : "");
+            response.sendRedirect(redirectUrl);
             return;
         }
 

--- a/src/test/java/net/dflmngr/services/ResultServiceTest.java
+++ b/src/test/java/net/dflmngr/services/ResultServiceTest.java
@@ -42,7 +42,7 @@ import net.dflmngr.repositories.DflSelectedPlayerRepository;
 import net.dflmngr.repositories.DflTeamPredictedScoresRepository;
 import net.dflmngr.repositories.DflTeamRepository;
 import net.dflmngr.repositories.DflTeamScoresRepository;
-import net.dflmngr.repositories.GlobalsRespository;
+import net.dflmngr.repositories.GlobalsRepository;
 import net.dflmngr.repositories.RawPlayerStatsRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,7 +59,7 @@ class ResultServiceTest {
     @Mock private DflPlayerPredictedScoresRepository dflPlayerPredictedScoresRepository;
     @Mock private DflTeamScoresRepository dflTeamScoresRepository;
     @Mock private DflTeamPredictedScoresRepository dflTeamPredictedScoresRepository;
-    @Mock private GlobalsRespository globalsRespository;
+    @Mock private GlobalsRepository globalsRespository;
 
     @InjectMocks
     private ResultService resultService;


### PR DESCRIPTION
## Summary
- **HttpsEnforcer**: redirect now preserves query string — uses `getRequestURI()` + `getQueryString()` instead of `getPathInfo()` which dropped query params
- **GlobalsRespository → GlobalsRepository**: corrected typo (missing 'o'), updated all references in `ResultService`, `ResultServiceTest`, and deleted old file

## Note
NPE risk in ResultService (backlog item #2) was already resolved by the N+1 refactor in PR #11 — `findByDflPlayerId` (null-returning) is no longer called anywhere.