### PR TITLE
Remove unused findByDflPlayerId and Thymeleaf leftovers in FixtureRestController

### DIFF
--- a/src/main/java/net/dflmngr/controllers/rest/FixtureRestController.java
+++ b/src/main/java/net/dflmngr/controllers/rest/FixtureRestController.java
@@ -2,9 +2,7 @@ package net.dflmngr.controllers.rest;
 
 import java.util.List;
 
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RestController;
 
 import net.dflmngr.model.web.RoundFixtures;
@@ -12,20 +10,15 @@ import net.dflmngr.services.FixtureService;
 
 @RestController
 public class FixtureRestController {
-	
+
 	private final FixtureService fixtureService;
 
-	public FixtureRestController(FixtureService fixtureRespository) {
-		this.fixtureService = fixtureRespository;
+	public FixtureRestController(FixtureService fixtureService) {
+		this.fixtureService = fixtureService;
 	}
-	
-    @ModelAttribute("module")
-    public String module() {
-        return "fixtures";
-    }
-	
+
 	@GetMapping(value = "/fixtures", produces = "application/json")
-	public List<RoundFixtures> fixtures(Model model) {		
-		return fixtureService.getFixtures();		
+	public List<RoundFixtures> fixtures() {
+		return fixtureService.getFixtures();
 	}
 }

--- a/src/main/java/net/dflmngr/repositories/AflPlayerRepository.java
+++ b/src/main/java/net/dflmngr/repositories/AflPlayerRepository.java
@@ -7,6 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import net.dflmngr.model.entities.AflPlayer;
 
 public interface AflPlayerRepository extends JpaRepository<AflPlayer, String>{
-	AflPlayer findByDflPlayerId(Integer playerId);
 	List<AflPlayer> findByDflPlayerIdIn(List<Integer> playerIds);
 }


### PR DESCRIPTION
## Summary
- Removes unused `AflPlayerRepository.findByDflPlayerId()` — the single-lookup method that returned null (not Optional), which was a latent NPE risk. It was never called after the Thymeleaf removal.
- Cleans up `FixtureRestController` — removes leftover `@ModelAttribute("module")` and `Model model` parameter from the old Thymeleaf days.