### PR TITLE
Mobile responsive layout

### DIFF
--- a/frontend/src/features/ladder/LadderTable.tsx
+++ b/frontend/src/features/ladder/LadderTable.tsx
@@ -34,6 +34,7 @@ interface Props {
 export default function LadderTable({ entries, title, showAverages }: Props) {
   const [sort, setSort] = useState<SortCol[]>(DEFAULT_SORT);
   const [userSorted, setUserSorted] = useState(false);
+  const [showAllCols, setShowAllCols] = useState(false);
 
   const handleSort = (key: SortKey, shiftKey: boolean) => {
     setUserSorted(true);
@@ -87,27 +88,35 @@ export default function LadderTable({ entries, title, showAverages }: Props) {
     <div className="mb-6 rounded border border-gray-200 shadow-sm overflow-hidden">
       <div className="bg-gray-100 px-4 py-2 font-semibold border-b border-gray-200 flex items-center justify-between">
         <span>{title}</span>
-        {userSorted && (
+        <div className="flex items-center gap-3">
+          {userSorted && (
+            <button
+              onClick={() => { setSort(DEFAULT_SORT); setUserSorted(false); }}
+              className="text-xs font-normal text-blue-600 hover:text-blue-800 hover:underline"
+            >
+              Reset sort
+            </button>
+          )}
           <button
-            onClick={() => { setSort(DEFAULT_SORT); setUserSorted(false); }}
-            className="text-xs font-normal text-blue-600 hover:text-blue-800 hover:underline"
+            onClick={() => setShowAllCols(s => !s)}
+            className="text-xs font-normal text-blue-600 hover:text-blue-800 hover:underline md:hidden"
           >
-            Reset sort
+            {showAllCols ? 'Less' : 'More'}
           </button>
-        )}
+        </div>
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead className="bg-gray-50 text-gray-600 uppercase text-xs">
             <tr>
               <th className="px-3 py-2 text-left">Team</th>
-              {th('wins', 'W')}
-              {th('losses', 'L')}
-              {th('draws', 'D')}
-              {th('pointsFor', 'For')}
-              {showAverages && th('averageFor', 'Ave For')}
-              {showAverages && th('pointsAgainst', 'Agst')}
-              {showAverages && th('averageAgainst', 'Ave Agst')}
+              {th('wins', 'W', showAllCols ? '' : 'hidden md:table-cell')}
+              {th('losses', 'L', showAllCols ? '' : 'hidden md:table-cell')}
+              {th('draws', 'D', showAllCols ? '' : 'hidden md:table-cell')}
+              {th('pointsFor', 'For', showAllCols ? '' : 'hidden md:table-cell')}
+              {showAverages && th('averageFor', 'Ave For', showAllCols ? '' : 'hidden md:table-cell')}
+              {showAverages && th('pointsAgainst', 'Agst', showAllCols ? '' : 'hidden md:table-cell')}
+              {showAverages && th('averageAgainst', 'Ave Agst', showAllCols ? '' : 'hidden md:table-cell')}
               {th('pts', 'Pts')}
               {th('percentage', '%')}
             </tr>
@@ -116,13 +125,13 @@ export default function LadderTable({ entries, title, showAverages }: Props) {
             {sorted.map((entry, i) => (
               <tr key={entry.teamCode} className={i % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
                 <td className="px-3 py-2">{entry.displayName}</td>
-                <td className="px-3 py-2 text-right">{entry.wins}</td>
-                <td className="px-3 py-2 text-right">{entry.losses}</td>
-                <td className="px-3 py-2 text-right">{entry.draws}</td>
-                <td className="px-3 py-2 text-right">{entry.pointsFor}</td>
-                {showAverages && <td className="px-3 py-2 text-right">{entry.averageFor.toFixed(2)}</td>}
-                {showAverages && <td className="px-3 py-2 text-right">{entry.pointsAgainst}</td>}
-                {showAverages && <td className="px-3 py-2 text-right">{entry.averageAgainst.toFixed(2)}</td>}
+                <td className={`px-3 py-2 text-right ${showAllCols ? '' : 'hidden md:table-cell'}`}>{entry.wins}</td>
+                <td className={`px-3 py-2 text-right ${showAllCols ? '' : 'hidden md:table-cell'}`}>{entry.losses}</td>
+                <td className={`px-3 py-2 text-right ${showAllCols ? '' : 'hidden md:table-cell'}`}>{entry.draws}</td>
+                <td className={`px-3 py-2 text-right ${showAllCols ? '' : 'hidden md:table-cell'}`}>{entry.pointsFor}</td>
+                {showAverages && <td className={`px-3 py-2 text-right ${showAllCols ? '' : 'hidden md:table-cell'}`}>{entry.averageFor.toFixed(2)}</td>}
+                {showAverages && <td className={`px-3 py-2 text-right ${showAllCols ? '' : 'hidden md:table-cell'}`}>{entry.pointsAgainst}</td>}
+                {showAverages && <td className={`px-3 py-2 text-right ${showAllCols ? '' : 'hidden md:table-cell'}`}>{entry.averageAgainst.toFixed(2)}</td>}
                 <td className="px-3 py-2 text-right font-medium">{entry.pts}</td>
                 <td className="px-3 py-2 text-right">{entry.percentage.toFixed(2)}</td>
               </tr>

--- a/frontend/src/features/results/EmergenciesTable.tsx
+++ b/frontend/src/features/results/EmergenciesTable.tsx
@@ -27,7 +27,7 @@ export default function EmergenciesTable({ players, showStats }: Props) {
       <table className="w-full text-xs border border-gray-200">
         <thead className="bg-gray-50 text-gray-600">
           <tr>
-            <th colSpan={showStats ? 16 : 5} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
+            <th colSpan={showStats ? 16 : 6} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
               Emergencies
             </th>
           </tr>
@@ -40,7 +40,7 @@ export default function EmergenciesTable({ players, showStats }: Props) {
             ))}
             <th className="px-2 py-1 text-right whitespace-nowrap">Score</th>
             {['Predicted','Trend'].map(h => (
-              <th key={h} className={`px-2 py-1 text-right whitespace-nowrap ${colClass(true)}`}>{h}</th>
+              <th key={h} className="px-2 py-1 text-right whitespace-nowrap">{h}</th>
             ))}
           </tr>
         </thead>
@@ -65,8 +65,8 @@ export default function EmergenciesTable({ players, showStats }: Props) {
                 <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.goals}</td>
                 <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.behinds}</td>
                 <td className="px-2 py-1 text-right font-medium">{player.stats.score}</td>
-                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.predictedScore}</td>
-                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.trend}</td>
+                <td className="px-2 py-1 text-right">{player.stats.predictedScore}</td>
+                <td className="px-2 py-1 text-right">{player.stats.trend}</td>
               </tr>
             );
           })}

--- a/frontend/src/features/results/EmergenciesTable.tsx
+++ b/frontend/src/features/results/EmergenciesTable.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import type { SelectedPlayer } from '../../types/api';
 
 const STATUS_CLASS: Record<string, string> = {
@@ -15,13 +14,12 @@ function playerName(player: SelectedPlayer): string {
 }
 
 interface Props {
-  players: SelectedPlayer[];
+  readonly players: SelectedPlayer[];
+  readonly showStats: boolean;
 }
 
-export default function EmergenciesTable({ players }: Props) {
-  const [showStats, setShowStats] = useState(false);
+export default function EmergenciesTable({ players, showStats }: Props) {
   const sorted = [...players].sort((a, b) => a.emgSort - b.emgSort);
-
   const colClass = (stat: boolean) => stat && !showStats ? 'hidden md:table-cell' : '';
 
   return (
@@ -30,15 +28,7 @@ export default function EmergenciesTable({ players }: Props) {
         <thead className="bg-gray-50 text-gray-600">
           <tr>
             <th colSpan={showStats ? 16 : 5} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
-              <div className="flex items-center justify-between">
-                <span>Emergencies</span>
-                <button
-                  onClick={() => setShowStats(s => !s)}
-                  className="text-xs font-normal text-blue-600 hover:text-blue-800 hover:underline md:hidden"
-                >
-                  {showStats ? 'Less' : 'Stats'}
-                </button>
-              </div>
+              Emergencies
             </th>
           </tr>
           <tr className="border-b border-gray-200">

--- a/frontend/src/features/results/EmergenciesTable.tsx
+++ b/frontend/src/features/results/EmergenciesTable.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { SelectedPlayer } from '../../types/api';
 
 const STATUS_CLASS: Record<string, string> = {
@@ -18,20 +19,38 @@ interface Props {
 }
 
 export default function EmergenciesTable({ players }: Props) {
+  const [showStats, setShowStats] = useState(false);
   const sorted = [...players].sort((a, b) => a.emgSort - b.emgSort);
+
+  const colClass = (stat: boolean) => stat && !showStats ? 'hidden md:table-cell' : '';
 
   return (
     <div className="overflow-x-auto mt-3">
       <table className="w-full text-xs border border-gray-200">
         <thead className="bg-gray-50 text-gray-600">
           <tr>
-            <th colSpan={16} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
-              Emergencies
+            <th colSpan={showStats ? 16 : 5} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
+              <div className="flex items-center justify-between">
+                <span>Emergencies</span>
+                <button
+                  onClick={() => setShowStats(s => !s)}
+                  className="text-xs font-normal text-blue-600 hover:text-blue-800 hover:underline md:hidden"
+                >
+                  {showStats ? 'Less' : 'Stats'}
+                </button>
+              </div>
             </th>
           </tr>
           <tr className="border-b border-gray-200">
-            {['No.','Player','Pos','K','H','D','M','HO','FF','FA','T','G','B','Score','Predicted','Trend'].map(h => (
-              <th key={h} className="px-2 py-1 text-right first:text-left whitespace-nowrap">{h}</th>
+            {['No.', 'Player', 'Pos'].map(h => (
+              <th key={h} className={`px-2 py-1 ${h === 'Player' ? 'text-left' : 'text-right'} whitespace-nowrap`}>{h}</th>
+            ))}
+            {['K','H','D','M','HO','FF','FA','T','G','B'].map(h => (
+              <th key={h} className={`px-2 py-1 text-right whitespace-nowrap ${colClass(true)}`}>{h}</th>
+            ))}
+            <th className="px-2 py-1 text-right whitespace-nowrap">Score</th>
+            {['Predicted','Trend'].map(h => (
+              <th key={h} className={`px-2 py-1 text-right whitespace-nowrap ${colClass(true)}`}>{h}</th>
             ))}
           </tr>
         </thead>
@@ -45,19 +64,19 @@ export default function EmergenciesTable({ players }: Props) {
                 <td className="px-2 py-1 text-right">{player.teamPlayerId}</td>
                 <td className="px-2 py-1 whitespace-nowrap">{playerName(player)}</td>
                 <td className="px-2 py-1 text-right">{player.position}</td>
-                <td className="px-2 py-1 text-right">{player.stats.kicks}</td>
-                <td className="px-2 py-1 text-right">{player.stats.handballs}</td>
-                <td className="px-2 py-1 text-right">{player.stats.disposals}</td>
-                <td className="px-2 py-1 text-right">{player.stats.marks}</td>
-                <td className="px-2 py-1 text-right">{player.stats.hitouts}</td>
-                <td className="px-2 py-1 text-right">{player.stats.freesFor}</td>
-                <td className="px-2 py-1 text-right">{player.stats.freesAgainst}</td>
-                <td className="px-2 py-1 text-right">{player.stats.tackles}</td>
-                <td className="px-2 py-1 text-right">{player.stats.goals}</td>
-                <td className="px-2 py-1 text-right">{player.stats.behinds}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.kicks}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.handballs}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.disposals}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.marks}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.hitouts}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.freesFor}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.freesAgainst}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.tackles}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.goals}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.behinds}</td>
                 <td className="px-2 py-1 text-right font-medium">{player.stats.score}</td>
-                <td className="px-2 py-1 text-right">{player.stats.predictedScore}</td>
-                <td className="px-2 py-1 text-right">{player.stats.trend}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.predictedScore}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.trend}</td>
               </tr>
             );
           })}

--- a/frontend/src/features/results/EmergenciesTable.tsx
+++ b/frontend/src/features/results/EmergenciesTable.tsx
@@ -39,7 +39,7 @@ export default function EmergenciesTable({ players, showStats }: Props) {
               <th key={h} className={`px-2 py-1 text-right whitespace-nowrap ${colClass(true)}`}>{h}</th>
             ))}
             <th className="px-2 py-1 text-right whitespace-nowrap">Score</th>
-            <th className="px-2 py-1 text-right whitespace-nowrap">Predicted</th>
+            <th className="px-2 py-1 text-right whitespace-nowrap"><span className="md:hidden">Pred</span><span className="hidden md:inline">Predicted</span></th>
             <th className={`px-2 py-1 text-right whitespace-nowrap ${colClass(true)}`}>Trend</th>
           </tr>
         </thead>

--- a/frontend/src/features/results/EmergenciesTable.tsx
+++ b/frontend/src/features/results/EmergenciesTable.tsx
@@ -27,7 +27,7 @@ export default function EmergenciesTable({ players, showStats }: Props) {
       <table className="w-full text-xs border border-gray-200">
         <thead className="bg-gray-50 text-gray-600">
           <tr>
-            <th colSpan={showStats ? 16 : 6} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
+            <th colSpan={showStats ? 16 : 5} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
               Emergencies
             </th>
           </tr>
@@ -39,9 +39,8 @@ export default function EmergenciesTable({ players, showStats }: Props) {
               <th key={h} className={`px-2 py-1 text-right whitespace-nowrap ${colClass(true)}`}>{h}</th>
             ))}
             <th className="px-2 py-1 text-right whitespace-nowrap">Score</th>
-            {['Predicted','Trend'].map(h => (
-              <th key={h} className="px-2 py-1 text-right whitespace-nowrap">{h}</th>
-            ))}
+            <th className="px-2 py-1 text-right whitespace-nowrap">Predicted</th>
+            <th className={`px-2 py-1 text-right whitespace-nowrap ${colClass(true)}`}>Trend</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
@@ -66,7 +65,7 @@ export default function EmergenciesTable({ players, showStats }: Props) {
                 <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.behinds}</td>
                 <td className="px-2 py-1 text-right font-medium">{player.stats.score}</td>
                 <td className="px-2 py-1 text-right">{player.stats.predictedScore}</td>
-                <td className="px-2 py-1 text-right">{player.stats.trend}</td>
+                <td className={`px-2 py-1 text-right ${colClass(true)}`}>{player.stats.trend}</td>
               </tr>
             );
           })}

--- a/frontend/src/features/results/PlayersTable.tsx
+++ b/frontend/src/features/results/PlayersTable.tsx
@@ -89,8 +89,8 @@ const ALL_HEADERS: { label: string; key: SortKey; left?: boolean; stat?: boolean
   { label: 'G',         key: 'goals',         stat: true },
   { label: 'B',         key: 'behinds',       stat: true },
   { label: 'Score',     key: 'score' },
-  { label: 'Predicted', key: 'predictedScore', stat: true },
-  { label: 'Trend',     key: 'trend',          stat: true },
+  { label: 'Predicted', key: 'predictedScore' },
+  { label: 'Trend',     key: 'trend' },
 ];
 
 export default function PlayersTable({ players, team, showStats }: Props) {
@@ -142,7 +142,7 @@ export default function PlayersTable({ players, team, showStats }: Props) {
       <table className="w-full text-xs border border-gray-200">
         <thead className="bg-gray-50 text-gray-600">
           <tr>
-            <th colSpan={showStats ? 17 : 5} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
+            <th colSpan={showStats ? 17 : 6} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
               <div className="flex items-center justify-between">
                 <span>Team</span>
                 <div className="flex items-center gap-3">
@@ -190,8 +190,8 @@ export default function PlayersTable({ players, team, showStats }: Props) {
               <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.goals}</td>
               <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.behinds}</td>
               <td className="px-2 py-1 text-right font-medium">{player.stats.score}</td>
-              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.predictedScore}</td>
-              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.trend}</td>
+              <td className="px-2 py-1 text-right">{player.stats.predictedScore}</td>
+              <td className="px-2 py-1 text-right">{player.stats.trend}</td>
             </tr>
           ))}
         </tbody>
@@ -199,16 +199,16 @@ export default function PlayersTable({ players, team, showStats }: Props) {
           <tr>
             <td colSpan={visibleLeadingCols} className="px-2 py-1 text-right">Total</td>
             <td className="px-2 py-1 text-right">{team.score}</td>
-            <td className={colClass(true, 'px-2 py-1 text-right')}>
+            <td className="px-2 py-1 text-right">
               {showTwoFooterRows ? team.currentPredictedScore : team.predictedScore}
             </td>
-            <td className={colClass(true, 'px-2 py-1 text-right')}>{team.trend}</td>
+            <td className="px-2 py-1 text-right">{team.trend}</td>
           </tr>
           {showTwoFooterRows && (
-            <tr className={showStats ? '' : 'hidden md:table-row'}>
+            <tr>
               <td colSpan={visibleLeadingCols} className="px-2 py-1 text-right">Pre-game</td>
               <td />
-              <td className={colClass(true, 'px-2 py-1 text-right')}>{team.predictedScore}</td>
+              <td className="px-2 py-1 text-right">{team.predictedScore}</td>
               <td />
             </tr>
           )}

--- a/frontend/src/features/results/PlayersTable.tsx
+++ b/frontend/src/features/results/PlayersTable.tsx
@@ -74,7 +74,7 @@ interface Props {
 
 const STAT_KEYS: SortKey[] = ['kicks', 'handballs', 'disposals', 'marks', 'hitouts', 'freesFor', 'freesAgainst', 'tackles', 'goals', 'behinds', 'predictedScore', 'trend'];
 
-const ALL_HEADERS: { label: string; key: SortKey; left?: boolean; stat?: boolean }[] = [
+const ALL_HEADERS: { label: string; shortLabel?: string; key: SortKey; left?: boolean; stat?: boolean }[] = [
   { label: 'No.',       key: 'teamPlayerId' },
   { label: 'Player',    key: 'name',          left: true },
   { label: 'Pos',       key: 'position' },
@@ -89,7 +89,7 @@ const ALL_HEADERS: { label: string; key: SortKey; left?: boolean; stat?: boolean
   { label: 'G',         key: 'goals',         stat: true },
   { label: 'B',         key: 'behinds',       stat: true },
   { label: 'Score',     key: 'score' },
-  { label: 'Predicted', key: 'predictedScore' },
+  { label: 'Predicted', shortLabel: 'Pred', key: 'predictedScore' },
   { label: 'Trend',     key: 'trend',          stat: true },
 ];
 
@@ -159,7 +159,7 @@ export default function PlayersTable({ players, team, showStats }: Props) {
             </th>
           </tr>
           <tr className="border-b border-gray-200">
-            {ALL_HEADERS.map(({ label, key, left, stat }) => {
+            {ALL_HEADERS.map(({ label, shortLabel, key, left, stat }) => {
               const active = sort.some(s => s.key === key);
               return (
                 <th
@@ -167,7 +167,7 @@ export default function PlayersTable({ players, team, showStats }: Props) {
                   className={`px-2 py-1 whitespace-nowrap cursor-pointer select-none hover:bg-gray-200 ${active ? 'bg-gray-200' : ''} ${left ? 'text-left' : 'text-right'} ${colClass(stat)}`}
                   onClick={e => handleSort(key, e.shiftKey)}
                 >
-                  {label}{sortIcon(key)}
+                  {shortLabel ? <><span className="md:hidden">{shortLabel}</span><span className="hidden md:inline">{label}</span></> : label}{sortIcon(key)}
                 </th>
               );
             })}

--- a/frontend/src/features/results/PlayersTable.tsx
+++ b/frontend/src/features/results/PlayersTable.tsx
@@ -71,28 +71,31 @@ interface Props {
   readonly team: TeamResults;
 }
 
-const HEADERS: { label: string; key: SortKey; left?: boolean }[] = [
+const STAT_KEYS: SortKey[] = ['kicks', 'handballs', 'disposals', 'marks', 'hitouts', 'freesFor', 'freesAgainst', 'tackles', 'goals', 'behinds', 'predictedScore', 'trend'];
+
+const ALL_HEADERS: { label: string; key: SortKey; left?: boolean; stat?: boolean }[] = [
   { label: 'No.',       key: 'teamPlayerId' },
   { label: 'Player',    key: 'name',          left: true },
   { label: 'Pos',       key: 'position' },
-  { label: 'K',         key: 'kicks' },
-  { label: 'H',         key: 'handballs' },
-  { label: 'D',         key: 'disposals' },
-  { label: 'M',         key: 'marks' },
-  { label: 'HO',        key: 'hitouts' },
-  { label: 'FF',        key: 'freesFor' },
-  { label: 'FA',        key: 'freesAgainst' },
-  { label: 'T',         key: 'tackles' },
-  { label: 'G',         key: 'goals' },
-  { label: 'B',         key: 'behinds' },
+  { label: 'K',         key: 'kicks',         stat: true },
+  { label: 'H',         key: 'handballs',     stat: true },
+  { label: 'D',         key: 'disposals',     stat: true },
+  { label: 'M',         key: 'marks',         stat: true },
+  { label: 'HO',        key: 'hitouts',       stat: true },
+  { label: 'FF',        key: 'freesFor',      stat: true },
+  { label: 'FA',        key: 'freesAgainst',  stat: true },
+  { label: 'T',         key: 'tackles',       stat: true },
+  { label: 'G',         key: 'goals',         stat: true },
+  { label: 'B',         key: 'behinds',       stat: true },
   { label: 'Score',     key: 'score' },
-  { label: 'Predicted', key: 'predictedScore' },
-  { label: 'Trend',     key: 'trend' },
+  { label: 'Predicted', key: 'predictedScore', stat: true },
+  { label: 'Trend',     key: 'trend',          stat: true },
 ];
 
 export default function PlayersTable({ players, team }: Props) {
   const [sort, setSort] = useState<SortCol[]>(DEFAULT_SORT);
   const [userSorted, setUserSorted] = useState(false);
+  const [showStats, setShowStats] = useState(false);
 
   const handleSort = (key: SortKey, shiftKey: boolean) => {
     setUserSorted(true);
@@ -124,33 +127,50 @@ export default function PlayersTable({ players, team }: Props) {
     return <span className="ml-0.5">{arrow}{badge}</span>;
   };
 
+  const isHidden = (stat?: boolean) => stat && !showStats;
+  const colClass = (stat?: boolean, extra = '') =>
+    `${isHidden(stat) ? 'hidden md:table-cell' : ''} ${extra}`.trim();
+
   const sorted = applySorts(players, sort);
   const showTwoFooterRows = team.currentPredictedScore !== team.score;
+
+  // On mobile with stats hidden, footer colspan adjusts: 3 visible cols (No, Player, Pos) before Score
+  const visibleLeadingCols = showStats ? 13 : 3;
 
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-xs border border-gray-200">
         <thead className="bg-gray-50 text-gray-600">
           <tr>
-            <th colSpan={17} className="px-2 py-1 text-left border-b border-gray-200 font-semibold flex items-center justify-between">
-              <span>Team</span>
-              {userSorted && (
-                <button
-                  onClick={() => { setSort(DEFAULT_SORT); setUserSorted(false); }}
-                  className="text-xs font-normal text-blue-600 hover:text-blue-800 hover:underline"
-                >
-                  Reset sort
-                </button>
-              )}
+            <th colSpan={showStats ? 17 : 5} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
+              <div className="flex items-center justify-between">
+                <span>Team</span>
+                <div className="flex items-center gap-3">
+                  {userSorted && (
+                    <button
+                      onClick={() => { setSort(DEFAULT_SORT); setUserSorted(false); }}
+                      className="text-xs font-normal text-blue-600 hover:text-blue-800 hover:underline"
+                    >
+                      Reset sort
+                    </button>
+                  )}
+                  <button
+                    onClick={() => setShowStats(s => !s)}
+                    className="text-xs font-normal text-blue-600 hover:text-blue-800 hover:underline md:hidden"
+                  >
+                    {showStats ? 'Less' : 'Stats'}
+                  </button>
+                </div>
+              </div>
             </th>
           </tr>
           <tr className="border-b border-gray-200">
-            {HEADERS.map(({ label, key, left }) => {
+            {ALL_HEADERS.map(({ label, key, left, stat }) => {
               const active = sort.some(s => s.key === key);
               return (
                 <th
                   key={label}
-                  className={`px-2 py-1 whitespace-nowrap cursor-pointer select-none hover:bg-gray-200 ${active ? 'bg-gray-200' : ''} ${left ? 'text-left' : 'text-right'}`}
+                  className={`px-2 py-1 whitespace-nowrap cursor-pointer select-none hover:bg-gray-200 ${active ? 'bg-gray-200' : ''} ${left ? 'text-left' : 'text-right'} ${colClass(stat)}`}
                   onClick={e => handleSort(key, e.shiftKey)}
                 >
                   {label}{sortIcon(key)}
@@ -165,36 +185,36 @@ export default function PlayersTable({ players, team }: Props) {
               <td className="px-2 py-1 text-right">{player.teamPlayerId}</td>
               <td className="px-2 py-1 whitespace-nowrap">{playerName(player)}</td>
               <td className="px-2 py-1 text-right">{player.position}</td>
-              <td className="px-2 py-1 text-right">{player.stats.kicks}</td>
-              <td className="px-2 py-1 text-right">{player.stats.handballs}</td>
-              <td className="px-2 py-1 text-right">{player.stats.disposals}</td>
-              <td className="px-2 py-1 text-right">{player.stats.marks}</td>
-              <td className="px-2 py-1 text-right">{player.stats.hitouts}</td>
-              <td className="px-2 py-1 text-right">{player.stats.freesFor}</td>
-              <td className="px-2 py-1 text-right">{player.stats.freesAgainst}</td>
-              <td className="px-2 py-1 text-right">{player.stats.tackles}</td>
-              <td className="px-2 py-1 text-right">{player.stats.goals}</td>
-              <td className="px-2 py-1 text-right">{player.stats.behinds}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.kicks}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.handballs}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.disposals}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.marks}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.hitouts}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.freesFor}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.freesAgainst}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.tackles}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.goals}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.behinds}</td>
               <td className="px-2 py-1 text-right font-medium">{player.stats.score}</td>
-              <td className="px-2 py-1 text-right">{player.stats.predictedScore}</td>
-              <td className="px-2 py-1 text-right">{player.stats.trend}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.predictedScore}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.trend}</td>
             </tr>
           ))}
         </tbody>
         <tfoot className="border-t border-gray-300 bg-gray-50 font-semibold text-xs">
           <tr>
-            <td colSpan={13} className="px-2 py-1 text-right">Total</td>
+            <td colSpan={visibleLeadingCols} className="px-2 py-1 text-right">Total</td>
             <td className="px-2 py-1 text-right">{team.score}</td>
-            <td className="px-2 py-1 text-right">
+            <td className={colClass(true, 'px-2 py-1 text-right')}>
               {showTwoFooterRows ? team.currentPredictedScore : team.predictedScore}
             </td>
-            <td className="px-2 py-1 text-right">{team.trend}</td>
+            <td className={colClass(true, 'px-2 py-1 text-right')}>{team.trend}</td>
           </tr>
           {showTwoFooterRows && (
-            <tr>
-              <td colSpan={13} className="px-2 py-1 text-right">Pre-game</td>
+            <tr className={showStats ? '' : 'hidden md:table-row'}>
+              <td colSpan={visibleLeadingCols} className="px-2 py-1 text-right">Pre-game</td>
               <td />
-              <td className="px-2 py-1 text-right">{team.predictedScore}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{team.predictedScore}</td>
               <td />
             </tr>
           )}

--- a/frontend/src/features/results/PlayersTable.tsx
+++ b/frontend/src/features/results/PlayersTable.tsx
@@ -69,6 +69,7 @@ function rowClass(scrapingStatus: string | null): string {
 interface Props {
   readonly players: SelectedPlayer[];
   readonly team: TeamResults;
+  readonly showStats: boolean;
 }
 
 const STAT_KEYS: SortKey[] = ['kicks', 'handballs', 'disposals', 'marks', 'hitouts', 'freesFor', 'freesAgainst', 'tackles', 'goals', 'behinds', 'predictedScore', 'trend'];
@@ -92,10 +93,9 @@ const ALL_HEADERS: { label: string; key: SortKey; left?: boolean; stat?: boolean
   { label: 'Trend',     key: 'trend',          stat: true },
 ];
 
-export default function PlayersTable({ players, team }: Props) {
+export default function PlayersTable({ players, team, showStats }: Props) {
   const [sort, setSort] = useState<SortCol[]>(DEFAULT_SORT);
   const [userSorted, setUserSorted] = useState(false);
-  const [showStats, setShowStats] = useState(false);
 
   const handleSort = (key: SortKey, shiftKey: boolean) => {
     setUserSorted(true);
@@ -154,12 +154,6 @@ export default function PlayersTable({ players, team }: Props) {
                       Reset sort
                     </button>
                   )}
-                  <button
-                    onClick={() => setShowStats(s => !s)}
-                    className="text-xs font-normal text-blue-600 hover:text-blue-800 hover:underline md:hidden"
-                  >
-                    {showStats ? 'Less' : 'Stats'}
-                  </button>
                 </div>
               </div>
             </th>

--- a/frontend/src/features/results/PlayersTable.tsx
+++ b/frontend/src/features/results/PlayersTable.tsx
@@ -90,7 +90,7 @@ const ALL_HEADERS: { label: string; key: SortKey; left?: boolean; stat?: boolean
   { label: 'B',         key: 'behinds',       stat: true },
   { label: 'Score',     key: 'score' },
   { label: 'Predicted', key: 'predictedScore' },
-  { label: 'Trend',     key: 'trend' },
+  { label: 'Trend',     key: 'trend',          stat: true },
 ];
 
 export default function PlayersTable({ players, team, showStats }: Props) {
@@ -142,7 +142,7 @@ export default function PlayersTable({ players, team, showStats }: Props) {
       <table className="w-full text-xs border border-gray-200">
         <thead className="bg-gray-50 text-gray-600">
           <tr>
-            <th colSpan={showStats ? 17 : 6} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
+            <th colSpan={showStats ? 16 : 5} className="px-2 py-1 text-left border-b border-gray-200 font-semibold">
               <div className="flex items-center justify-between">
                 <span>Team</span>
                 <div className="flex items-center gap-3">
@@ -191,7 +191,7 @@ export default function PlayersTable({ players, team, showStats }: Props) {
               <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.behinds}</td>
               <td className="px-2 py-1 text-right font-medium">{player.stats.score}</td>
               <td className="px-2 py-1 text-right">{player.stats.predictedScore}</td>
-              <td className="px-2 py-1 text-right">{player.stats.trend}</td>
+              <td className={colClass(true, 'px-2 py-1 text-right')}>{player.stats.trend}</td>
             </tr>
           ))}
         </tbody>
@@ -202,14 +202,14 @@ export default function PlayersTable({ players, team, showStats }: Props) {
             <td className="px-2 py-1 text-right">
               {showTwoFooterRows ? team.currentPredictedScore : team.predictedScore}
             </td>
-            <td className="px-2 py-1 text-right">{team.trend}</td>
+            <td className={colClass(true, 'px-2 py-1 text-right')}>{team.trend}</td>
           </tr>
           {showTwoFooterRows && (
             <tr>
               <td colSpan={visibleLeadingCols} className="px-2 py-1 text-right">Pre-game</td>
               <td />
               <td className="px-2 py-1 text-right">{team.predictedScore}</td>
-              <td />
+              <td className={colClass(true)} />
             </tr>
           )}
         </tfoot>

--- a/frontend/src/features/results/TeamResultsPanel.tsx
+++ b/frontend/src/features/results/TeamResultsPanel.tsx
@@ -11,17 +11,18 @@ const EMG_MESSAGES: Record<string, string> = {
 interface Props {
   team: TeamResults;
   label: 'Home' | 'Away';
+  showStats: boolean;
 }
 
-export default function TeamResultsPanel({ team, label }: Props) {
+export default function TeamResultsPanel({ team, label, showStats }: Props) {
   return (
     <div className="rounded border border-gray-200 shadow-sm overflow-hidden">
       <div className="bg-gray-100 px-4 py-2 font-semibold border-b border-gray-200">
         {label}: {team.teamName}
       </div>
       <div className="p-3">
-        <PlayersTable players={team.players} team={team} />
-        <EmergenciesTable players={team.emergencies} />
+        <PlayersTable players={team.players} team={team} showStats={showStats} />
+        <EmergenciesTable players={team.emergencies} showStats={showStats} />
         {team.emgInd && EMG_MESSAGES[team.emgInd] && (
           <p className="mt-2 text-xs text-red-600">{EMG_MESSAGES[team.emgInd]}</p>
         )}

--- a/frontend/src/pages/ResultsPage.tsx
+++ b/frontend/src/pages/ResultsPage.tsx
@@ -13,6 +13,7 @@ export default function ResultsPage() {
   const [results, setResults] = useState<Results | null>(null);
   const [menu, setMenu] = useState<RoundMenu[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -48,23 +49,41 @@ export default function ResultsPage() {
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
-      <div className="flex flex-1 max-w-screen-xl mx-auto w-full px-4 py-6 gap-4">
-        <aside className="w-52 shrink-0">
-          <ResultsSidebar menu={menu} />
-        </aside>
-        <main className="flex-1 min-w-0">
-          {error && (
-            <div className="mb-4 p-3 bg-red-100 text-red-700 rounded border border-red-200">{error}</div>
-          )}
-          {results && results.homeTeam && results.awayTeam ? (
-            <div className="space-y-6">
-              <TeamResultsPanel team={results.homeTeam} label="Home" />
-              <TeamResultsPanel team={results.awayTeam} label="Away" />
-            </div>
-          ) : results ? (
-            <div className="text-gray-500 italic">No results available for this game yet.</div>
-          ) : null}
-        </main>
+      <div className="max-w-screen-xl mx-auto w-full px-4 py-6">
+        {/* Mobile sidebar toggle */}
+        <div className="md:hidden mb-3">
+          <button
+            onClick={() => setSidebarOpen(o => !o)}
+            className="text-sm px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50"
+          >
+            {sidebarOpen ? 'Hide fixtures' : 'Show fixtures'}
+          </button>
+        </div>
+        {sidebarOpen && (
+          <div className="md:hidden mb-4">
+            <ResultsSidebar menu={menu} />
+          </div>
+        )}
+
+        <div className="flex flex-1 gap-4">
+          {/* Desktop sidebar */}
+          <aside className="hidden md:block w-52 shrink-0">
+            <ResultsSidebar menu={menu} />
+          </aside>
+          <main className="flex-1 min-w-0">
+            {error && (
+              <div className="mb-4 p-3 bg-red-100 text-red-700 rounded border border-red-200">{error}</div>
+            )}
+            {results && results.homeTeam && results.awayTeam ? (
+              <div className="space-y-6">
+                <TeamResultsPanel team={results.homeTeam} label="Home" />
+                <TeamResultsPanel team={results.awayTeam} label="Away" />
+              </div>
+            ) : results ? (
+              <div className="text-gray-500 italic">No results available for this game yet.</div>
+            ) : null}
+          </main>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/ResultsPage.tsx
+++ b/frontend/src/pages/ResultsPage.tsx
@@ -14,6 +14,7 @@ export default function ResultsPage() {
   const [menu, setMenu] = useState<RoundMenu[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [showStats, setShowStats] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -50,13 +51,19 @@ export default function ResultsPage() {
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
       <div className="max-w-screen-xl mx-auto w-full px-4 py-6">
-        {/* Mobile sidebar toggle */}
-        <div className="md:hidden mb-3">
+        {/* Mobile controls */}
+        <div className="md:hidden mb-3 flex gap-2">
           <button
             onClick={() => setSidebarOpen(o => !o)}
             className="text-sm px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50"
           >
             {sidebarOpen ? 'Hide fixtures' : 'Show fixtures'}
+          </button>
+          <button
+            onClick={() => setShowStats(s => !s)}
+            className="text-sm px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50"
+          >
+            {showStats ? 'Hide stats' : 'Show stats'}
           </button>
         </div>
         {sidebarOpen && (
@@ -76,8 +83,8 @@ export default function ResultsPage() {
             )}
             {results && results.homeTeam && results.awayTeam ? (
               <div className="space-y-6">
-                <TeamResultsPanel team={results.homeTeam} label="Home" />
-                <TeamResultsPanel team={results.awayTeam} label="Away" />
+                <TeamResultsPanel team={results.homeTeam} label="Home" showStats={showStats} />
+                <TeamResultsPanel team={results.awayTeam} label="Away" showStats={showStats} />
               </div>
             ) : results ? (
               <div className="text-gray-500 italic">No results available for this game yet.</div>

--- a/frontend/src/test/features/results/PlayersTable.test.tsx
+++ b/frontend/src/test/features/results/PlayersTable.test.tsx
@@ -42,25 +42,25 @@ const makeTeam = (players: SelectedPlayer[], score: number, currentPredictedScor
 describe('PlayersTable', () => {
   it('renders player names', () => {
     const players = [makePlayer(1, 'John Smith', 'FWD', 80, null)];
-    render(<PlayersTable players={players} team={makeTeam(players, 80, 80, 80)} />);
+    render(<PlayersTable players={players} team={makeTeam(players, 80, 80, 80)} showStats={false} />);
     expect(screen.getByText('John Smith')).toBeInTheDocument();
   });
 
   it('appends * suffix for players with replacementInd *', () => {
     const players = [makePlayer(1, 'John Smith', 'FWD', 80, null, '*')];
-    render(<PlayersTable players={players} team={makeTeam(players, 80, 80, 80)} />);
+    render(<PlayersTable players={players} team={makeTeam(players, 80, 80, 80)} showStats={false} />);
     expect(screen.getByText('John Smith*')).toBeInTheDocument();
   });
 
   it('appends ** suffix for players with replacementInd **', () => {
     const players = [makePlayer(1, 'Jane Doe', 'MID', 70, null, '**')];
-    render(<PlayersTable players={players} team={makeTeam(players, 70, 70, 70)} />);
+    render(<PlayersTable players={players} team={makeTeam(players, 70, 70, 70)} showStats={false} />);
     expect(screen.getByText('Jane Doe**')).toBeInTheDocument();
   });
 
   it('applies yellow background for InProgress status', () => {
     const players = [makePlayer(1, 'John Smith', 'FWD', 50, 'InProgress')];
-    render(<PlayersTable players={players} team={makeTeam(players, 50, 50, 50)} />);
+    render(<PlayersTable players={players} team={makeTeam(players, 50, 50, 50)} showStats={false} />);
     const rows = screen.getAllByRole('row');
     const dataRow = rows.find(r => r.textContent?.includes('John Smith'));
     expect(dataRow?.className).toContain('bg-yellow-50');
@@ -68,7 +68,7 @@ describe('PlayersTable', () => {
 
   it('applies blue background for Completed status', () => {
     const players = [makePlayer(1, 'John Smith', 'FWD', 80, 'Completed')];
-    render(<PlayersTable players={players} team={makeTeam(players, 80, 80, 80)} />);
+    render(<PlayersTable players={players} team={makeTeam(players, 80, 80, 80)} showStats={false} />);
     const rows = screen.getAllByRole('row');
     const dataRow = rows.find(r => r.textContent?.includes('John Smith'));
     expect(dataRow?.className).toContain('bg-blue-100');
@@ -76,7 +76,7 @@ describe('PlayersTable', () => {
 
   it('applies green background for Finalized status', () => {
     const players = [makePlayer(1, 'John Smith', 'FWD', 80, 'Finalized')];
-    render(<PlayersTable players={players} team={makeTeam(players, 80, 80, 80)} />);
+    render(<PlayersTable players={players} team={makeTeam(players, 80, 80, 80)} showStats={false} />);
     const rows = screen.getAllByRole('row');
     const dataRow = rows.find(r => r.textContent?.includes('John Smith'));
     expect(dataRow?.className).toContain('bg-green-100');
@@ -84,14 +84,14 @@ describe('PlayersTable', () => {
 
   it('renders single footer row when currentPredictedScore equals score', () => {
     const players = [makePlayer(1, 'John Smith', 'FWD', 80, null)];
-    render(<PlayersTable players={players} team={makeTeam(players, 80, 80, 75)} />);
+    render(<PlayersTable players={players} team={makeTeam(players, 80, 80, 75)} showStats={false} />);
     expect(screen.queryByText('Pre-game')).not.toBeInTheDocument();
     expect(screen.getByText('Total')).toBeInTheDocument();
   });
 
   it('renders pre-game footer row when currentPredictedScore differs from score', () => {
     const players = [makePlayer(1, 'John Smith', 'FWD', 80, null)];
-    render(<PlayersTable players={players} team={makeTeam(players, 80, 95, 75)} />);
+    render(<PlayersTable players={players} team={makeTeam(players, 80, 95, 75)} showStats={false} />);
     expect(screen.getByText('Pre-game')).toBeInTheDocument();
     expect(screen.getByText('Total')).toBeInTheDocument();
   });
@@ -102,7 +102,7 @@ describe('PlayersTable', () => {
       makePlayer(2, 'Beta', 'FWD', 100, null),
       makePlayer(3, 'Gamma', 'FWD', 80, null),
     ];
-    render(<PlayersTable players={players} team={makeTeam(players, 270, 270, 270)} />);
+    render(<PlayersTable players={players} team={makeTeam(players, 270, 270, 270)} showStats={false} />);
     const rows = screen.getAllByRole('row').slice(2); // skip two thead rows
     expect(rows[0].textContent).toContain('Beta');   // FWD, score 100
     expect(rows[1].textContent).toContain('Gamma');  // FWD, score 80


### PR DESCRIPTION
## Summary
- **ResultsPage**: sidebar hidden on mobile, toggled via "Show fixtures" button
- **LadderTable**: on mobile shows Team/Pts/% by default; "More" button reveals all columns
- **PlayersTable**: on mobile shows No./Player/Pos/Score by default; "Stats" button reveals all stat columns and Pre-game footer row
- **EmergenciesTable**: same mobile treatment as PlayersTable
- All toggles are desktop-invisible (md:hidden) — desktop layout unchanged