### PR TITLE
Fix Total/Pre-game footer alignment on desktop

### DIFF
--- a/frontend/src/features/results/PlayersTable.tsx
+++ b/frontend/src/features/results/PlayersTable.tsx
@@ -134,9 +134,6 @@ export default function PlayersTable({ players, team, showStats }: Props) {
   const sorted = applySorts(players, sort);
   const showTwoFooterRows = team.currentPredictedScore !== team.score;
 
-  // On mobile with stats hidden, footer colspan adjusts: 3 visible cols (No, Player, Pos) before Score
-  const visibleLeadingCols = showStats ? 13 : 3;
-
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-xs border border-gray-200">
@@ -197,7 +194,10 @@ export default function PlayersTable({ players, team, showStats }: Props) {
         </tbody>
         <tfoot className="border-t border-gray-300 bg-gray-50 font-semibold text-xs">
           <tr>
-            <td colSpan={visibleLeadingCols} className="px-2 py-1 text-right">Total</td>
+            <td className="px-2 py-1" />
+            <td className="px-2 py-1" />
+            <td className="px-2 py-1 text-right">Total</td>
+            {STAT_KEYS.slice(0, 10).map(k => <td key={k} className={colClass(true)} />)}
             <td className="px-2 py-1 text-right">{team.score}</td>
             <td className="px-2 py-1 text-right">
               {showTwoFooterRows ? team.currentPredictedScore : team.predictedScore}
@@ -206,7 +206,10 @@ export default function PlayersTable({ players, team, showStats }: Props) {
           </tr>
           {showTwoFooterRows && (
             <tr>
-              <td colSpan={visibleLeadingCols} className="px-2 py-1 text-right">Pre-game</td>
+              <td className="px-2 py-1" />
+              <td className="px-2 py-1" />
+              <td className="px-2 py-1 text-right">Pre-game</td>
+              {STAT_KEYS.slice(0, 10).map(k => <td key={k} className={colClass(true)} />)}
               <td />
               <td className="px-2 py-1 text-right">{team.predictedScore}</td>
               <td className={colClass(true)} />


### PR DESCRIPTION
## Summary
- Replace `colSpan={visibleLeadingCols}` in the footer with explicit cells per column using the same `colClass(true)` visibility as the data rows
- Root cause: `showStats` is a mobile-only toggle — desktop always shows stat columns regardless, so using it to compute footer colspan caused misalignment on desktop

## Test plan
- [ ] Verify Total row aligns with Score column on desktop
- [ ] Verify Pre-game row aligns with Predicted column on desktop
- [ ] Verify both rows still align correctly on mobile with stats hidden/shown