### PR TITLE
Show last updated timestamp on results page

### DIFF
--- a/frontend/src/pages/ResultsPage.tsx
+++ b/frontend/src/pages/ResultsPage.tsx
@@ -15,6 +15,7 @@ export default function ResultsPage() {
   const [error, setError] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [showStats, setShowStats] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -36,6 +37,7 @@ export default function ResultsPage() {
       ]);
       setResults(r);
       setMenu(m);
+      setLastUpdated(new Date());
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load results');
     }
@@ -80,6 +82,9 @@ export default function ResultsPage() {
           <main className="flex-1 min-w-0">
             {error && (
               <div className="mb-4 p-3 bg-red-100 text-red-700 rounded border border-red-200">{error}</div>
+            )}
+            {lastUpdated && (
+              <p className="mb-3 text-xs text-gray-400">Updated {lastUpdated.toLocaleTimeString()}</p>
             )}
             {results && results.homeTeam && results.awayTeam ? (
               <div className="space-y-6">

--- a/frontend/src/pages/ResultsPage.tsx
+++ b/frontend/src/pages/ResultsPage.tsx
@@ -84,7 +84,7 @@ export default function ResultsPage() {
               <div className="mb-4 p-3 bg-red-100 text-red-700 rounded border border-red-200">{error}</div>
             )}
             {lastUpdated && (
-              <p className="mb-3 text-xs text-gray-400">Updated {lastUpdated.toLocaleTimeString()}</p>
+              <p className="mb-3 text-xs text-gray-400">Updated {lastUpdated.toLocaleString()}</p>
             )}
             {results && results.homeTeam && results.awayTeam ? (
               <div className="space-y-6">


### PR DESCRIPTION
## Summary
- Adds a small "Updated HH:MM:SS AM/PM" timestamp above the results panels
- Timestamp updates on every successful data fetch (initial load + every 5 min poll)

## Test plan
- [ ] Timestamp appears after results load
- [ ] Timestamp updates after each auto-refresh