### PR TITLE
Add global exception handler for REST controllers

### DIFF
--- a/src/main/java/net/dflmngr/controllers/rest/GlobalExceptionHandler.java
+++ b/src/main/java/net/dflmngr/controllers/rest/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package net.dflmngr.controllers.rest;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice(basePackages = "net.dflmngr.controllers.rest")
+public class GlobalExceptionHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<Map<String, String>> handleNotFound(NoSuchElementException ex) {
+        logger.warn("Resource not found: {}", ex.getMessage());
+        return ResponseEntity.status(404).body(Map.of("error", "Not found"));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleException(Exception ex) {
+        logger.error("Unhandled exception", ex);
+        return ResponseEntity.status(500).body(Map.of("error", "Internal server error"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GlobalExceptionHandler` scoped to `net.dflmngr.controllers.rest`
- `NoSuchElementException` → WARN log + 404 response
- Unhandled `Exception` → ERROR log with stack trace + 500 response

Previously unhandled exceptions (e.g. `.orElseThrow()` failures) would bubble up silently with no log entry.