### PR TITLE
Add Spring Boot Actuator health check endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
 			<artifactId>postgresql</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,11 @@ spring:
       connection-timeout: 5000
       minimum-idle: 2
       maximum-pool-size: 5
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
 logging:
   level:
     net:


### PR DESCRIPTION
## Summary
- Adds `spring-boot-starter-actuator` dependency
- Exposes only `/actuator/health` — all other actuator endpoints remain off
- Returns `{"status":"UP"}` when healthy, `{"status":"DOWN"}` when not