### PR TITLE
Move controller advice to dedicated package and improve error messages

### DIFF
--- a/src/main/java/net/dflmngr/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/net/dflmngr/controllers/advice/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package net.dflmngr.controllers.rest;
+package net.dflmngr.controllers.advice;
 
 import java.util.Map;
 import java.util.NoSuchElementException;

--- a/src/main/java/net/dflmngr/controllers/advice/NoCacheAdvice.java
+++ b/src/main/java/net/dflmngr/controllers/advice/NoCacheAdvice.java
@@ -1,4 +1,4 @@
-package net.dflmngr.controllers.rest;
+package net.dflmngr.controllers.advice;
 
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;

--- a/src/main/java/net/dflmngr/services/ResultService.java
+++ b/src/main/java/net/dflmngr/services/ResultService.java
@@ -147,7 +147,8 @@ public class ResultService {
 		globalsPK.setCode("currentRound");
 		globalsPK.setGroupCode("dflRef");
 		
-		Globals currentRoundGlobal = globalsRespository.findById(globalsPK).orElseThrow();
+		Globals currentRoundGlobal = globalsRespository.findById(globalsPK)
+				.orElseThrow(() -> new NoSuchElementException("Global config not found: code=currentRound groupCode=dflRef"));
 		int currentRound = Integer.parseInt(currentRoundGlobal.getValue());
 		return getResults(currentRound, 1);
 
@@ -224,7 +225,8 @@ public class ResultService {
 		TeamResults teamResults = new TeamResults();
 
 		if(teamCode != null) {
-			DflTeam team = dflTeamRepository.findById(teamCode).orElseThrow();
+			DflTeam team = dflTeamRepository.findById(teamCode)
+					.orElseThrow(() -> new NoSuchElementException("Team not found: teamCode=" + teamCode));
 			teamResults.setTeamCode(teamCode);
 			teamResults.setTeamName(team.getName());
 
@@ -247,7 +249,8 @@ public class ResultService {
 			DflTeamPredictedScoresPK dflTeamPredictedScoresPK = new DflTeamPredictedScoresPK();
 			dflTeamPredictedScoresPK.setRound(round);
 			dflTeamPredictedScoresPK.setTeamCode(teamCode);
-			DflTeamPredictedScores dflTeamPredictedScore = dflTeamPredictedScoresRepository.findById(dflTeamPredictedScoresPK).orElseThrow();
+			DflTeamPredictedScores dflTeamPredictedScore = dflTeamPredictedScoresRepository.findById(dflTeamPredictedScoresPK)
+					.orElseThrow(() -> new NoSuchElementException("Predicted scores not found: round=" + round + " teamCode=" + teamCode));
 
 			if(dflTeamScore != null) {
 				teamResults.setScore(dflTeamScore.getScore());


### PR DESCRIPTION
## Summary
- Move `NoCacheAdvice` and `GlobalExceptionHandler` from `controllers.rest` to `controllers.advice` package (both retain `basePackages = "net.dflmngr.controllers.rest"`)
- Add descriptive messages to silent `orElseThrow()` calls in `ResultService` so failures are visible in logs with context (round, teamCode, etc.)