### PR TITLE
Add warmup health indicator to delay traffic until services are warm

### DIFF
--- a/src/main/java/net/dflmngr/startup/WarmupHealthIndicator.java
+++ b/src/main/java/net/dflmngr/startup/WarmupHealthIndicator.java
@@ -1,0 +1,51 @@
+package net.dflmngr.startup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import net.dflmngr.services.LadderService;
+import net.dflmngr.services.ResultService;
+
+@Component
+public class WarmupHealthIndicator implements HealthIndicator {
+
+    private static final Logger logger = LoggerFactory.getLogger(WarmupHealthIndicator.class);
+
+    private final LadderService ladderService;
+    private final ResultService resultService;
+
+    private volatile boolean warmedUp = false;
+
+    public WarmupHealthIndicator(LadderService ladderService, ResultService resultService) {
+        this.ladderService = ladderService;
+        this.resultService = resultService;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void warmUp() {
+        logger.info("Starting warmup...");
+        try {
+            ladderService.getLadder();
+            ladderService.getLiveLadder();
+            resultService.getCurrentResults();
+            logger.info("Warmup complete");
+        } catch (Exception e) {
+            logger.warn("Warmup encountered an error: {}", e.getMessage());
+        } finally {
+            warmedUp = true;
+        }
+    }
+
+    @Override
+    public Health health() {
+        if (warmedUp) {
+            return Health.up().build();
+        }
+        return Health.down().withDetail("reason", "warming up").build();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `WarmupHealthIndicator` which reports `DOWN` until warmup completes, delaying Render traffic switchover
- On `ApplicationReadyEvent`, calls `getLadder()`, `getLiveLadder()`, and `getCurrentResults()` to pre-warm Hibernate, the DB connection pool, and JPA query plans
- Once warmup completes (success or error), health reports `UP` — app won't get stuck permanently unhealthy if warmup fails
- Addresses deploy-time latency spikes (p95 up to 3s) seen in Render metrics

## Test plan
- [ ] After merging, trigger a deploy and check logs for "Starting warmup..." and "Warmup complete"
- [ ] Check Render metrics after next deploy — p95 latency spikes at deploy time should be reduced